### PR TITLE
Add configuration 'taskwiki_default_tag'

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -665,6 +665,11 @@ constructs.
 
 ~   === Home habits | project:Home #H ===
 
+*taskwiki_default_tag*
+    Optional tag to be added to all tasks created or modified by Taskwiki.
+    Example:
+    let g:taskwiki_default_tag='wiki'
+
 *taskwiki_sort_order*
     The default sort order used to sort the tasks within viewports. Defaults
     to 'status+,end+,due+,pri-,project+'. Expects a comma-separated list of

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -260,6 +260,8 @@ class VimwikiTask(object):
             self.task['depends'] -= set(port.viewport_tasks)
 
         self.task['depends'] |= set(s.task for s in self.add_dependencies)
+        if util.get_var('taskwiki_default_tag'):
+            self.task['tags'] |= {util.get_var('taskwiki_default_tag')} 
 
         # Push the values to the Task only if the Vimwiki representation
         # somehow differs

--- a/tests/test_vwtask.py
+++ b/tests/test_vwtask.py
@@ -25,6 +25,33 @@ class TestSimpleTaskCreation(IntegrationTest):
         assert task['description'] == 'This is a test task'
         assert task['status'] == 'pending'
 
+class TestSimpleTaskCreationWithDefaultTag(IntegrationTest):
+
+    viminput = """
+    * [ ] This is a test task
+    """
+
+    vimoutput = """
+    * [ ] This is a test task  #{uuid}
+    """
+
+    def execute(self):
+        self.command('let g:taskwiki_default_tag="mytag"')
+        self.command("w", regex="written$", lines=1)
+
+        # Check that only one tasks with this description exists
+        assert len(self.tw.tasks.pending()) == 1
+
+        task = self.tw.tasks.pending()[0]
+        assert task['description'] == 'This is a test task'
+        assert task['status'] == 'pending'
+        # Tag was added
+        assert task['tags'] == {'mytag'}
+        
+        self.command('let g:taskwiki_default_tag="anothertag"')
+        self.command("w", regex="written$", lines=1)
+        # Existing tags are not overwritten
+        assert task['tags'] == {'mytag' 'anothertag'}
 
 class TestInvalidUUIDTask(IntegrationTest):
 


### PR DESCRIPTION
The idea is to automatically add a tag to all tasks created or modified from Taskwiki. This should make it easier to filter tasks on Taskwarrior to either remove tasks created from Vimwiki or to visualize only those tasks created from it.