### PR TITLE
Override vimwiki's CTRL+Space to mark task as done when already started.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ python:
   - "3.8"
 services:
   - docker
-before_install:
-  # Setup virtual framebuffer
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 install:
   # Install coverage dependencies
   - pip install coverage coveralls
@@ -25,7 +21,6 @@ install:
   - pushd $TRAVIS_BUILD_DIR
   - docker-compose build --build-arg TASK_VERSION=$TASK_VERSION tests
 script:
-  - xhost +local:root
   - make test
 after_success:
   - ls /tmp/taskwiki-coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,7 @@ RUN pip3 install -r requirements.txt
 RUN mkdir /root/.vim/bundle/taskwiki
 WORKDIR /root/.vim/bundle/taskwiki
 
-CMD ["sh", "-c", "python3 -m pytest -vv tests/"]
+# Setup xvfb
+RUN dnf install xorg-x11-server-Xvfb -y
+
+CMD ["sh", "-c", "xvfb-run python3 -m pytest -vv tests/"]

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -92,6 +92,13 @@ endif
 
 execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
 
+" Disable <C-Space> as VimwikiToggleListItem
+if !hasmapto('<Plug>VimwikiToggleListItem')
+  nmap <Plug>NoVimwikiToggleListItem <Plug>VimwikiToggleListItem
+endif
+
+execute "nnoremap <silent><buffer> <C-Space> :" . g:taskwiki_py . "Mappings.task_done_or_vimwiki_toggle_list_item()<CR>"
+
 " Leader-related mappings. Mostly <Leader>t + <first letter of the action>
 if !exists('g:taskwiki_suppress_mappings')
         if exists('g:taskwiki_maplocalleader')
@@ -103,6 +110,8 @@ if !exists('g:taskwiki_suppress_mappings')
                         let maplocalleader = '\t'
                 endif
         endif
+        " Override vimwiki's <C-Space>
+        nnoremap <silent><buffer> <C-Space> :TaskWikiDone<CR>
         nnoremap <silent><buffer> <LocalLeader>a :TaskWikiAnnotate<CR>
         nnoremap <silent><buffer> <LocalLeader>bd :TaskWikiBurndownDaily<CR>
         nnoremap <silent><buffer> <LocalLeader>bw :TaskWikiBurndownWeekly<CR>

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -26,7 +26,7 @@ let s:plugin_path = escape(expand('<sfile>:p:h:h:h'), '\')
 
 " Run the measure parts first, if desired
 if exists("g:taskwiki_measure_coverage")
-  execute 'py3file ' . s:plugin_path . '/knowledge/testcoverage.py'
+  execute 'py3file ' . s:plugin_path . '/taskwiki/testcoverage.py'
 endif
 
 " Execute the main body of taskwiki source

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -110,8 +110,6 @@ if !exists('g:taskwiki_suppress_mappings')
                         let maplocalleader = '\t'
                 endif
         endif
-        " Override vimwiki's <C-Space>
-        nnoremap <silent><buffer> <C-Space> :TaskWikiDone<CR>
         nnoremap <silent><buffer> <LocalLeader>a :TaskWikiAnnotate<CR>
         nnoremap <silent><buffer> <LocalLeader>bd :TaskWikiBurndownDaily<CR>
         nnoremap <silent><buffer> <LocalLeader>bw :TaskWikiBurndownWeekly<CR>

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -291,6 +291,20 @@ class Mappings(object):
         # VimwikiFollowLink for link creation
         vim.command('VimwikiFollowLink')
 
+    @staticmethod
+    @errors.pretty_exception_handler
+    def task_done_or_vimwiki_toggle_list_item():
+        # Reset the cache() to use up-to-date buffer content
+        cache().reset()
+
+        # If the line under cursor contains a task, mark as done
+        # otherwise fallback to VimwikiToggleListItem
+        row = util.get_current_line_number()
+        if cache().vwtask[row] is not None:
+            vim.command('TaskWikiDone')
+            return
+        vim.command('VimwikiToggleListItem')
+
 
 
 class Meta(object):

--- a/tests/base.py
+++ b/tests/base.py
@@ -21,10 +21,10 @@ class IntegrationTest(object):
     tasks = []
     markup = None
 
-    def add_plugin(self, name):
+    def add_plugin(self, name, init_script=''):
         plugin_base = os.path.expanduser('~/.vim/bundle/')
         plugin_path = os.path.join(plugin_base, name)
-        self.client.add_plugin(plugin_path)
+        self.client.add_plugin(plugin_path, init_script)
 
     def write_buffer(self, lines, position=0):
         result = self.client.write_buffer(position + 1, lines)
@@ -72,7 +72,8 @@ class IntegrationTest(object):
         self.command('let g:taskwiki_taskrc_location="{0}"'.format(self.taskrc_path))
         self.command("let g:vimwiki_list = [{'syntax': 'mediawiki', 'ext': '.txt','path': '%s'}]" % self.dir)
         self.command('let g:taskwiki_measure_coverage="yes"')
-        self.command('let g:taskwiki_markup_syntax="{0}"'.format(self.markup))
+        if self.markup is not None:
+            self.command('let g:taskwiki_markup_syntax="{0}"'.format(self.markup))
 
     def setup(self):
         self.generate_data()
@@ -84,12 +85,12 @@ class IntegrationTest(object):
 
         self.configure_global_varialbes()
         self.add_plugin('taskwiki')
-        self.add_plugin('vimwiki')
+        self.add_plugin('vimwiki', 'plugin/vimwiki.vim')
         sleep(0.5)
         self.filepath = os.path.join(self.dir, 'testwiki.txt')
         self.client.edit(self.filepath)
         sleep(0.5)
-        self.command('set filetype=vimwiki', silent=None)  # TODO: fix these vimwiki loading errors
+        self.command('set filetype=vimwiki')
         sleep(1)  # Give vim some time to load the scripts
 
     def teardown(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -235,12 +235,18 @@ class IntegrationTest(object):
 
 class MultiSyntaxIntegrationTest(IntegrationTest):
 
+    def setup(self):
+        # We have to delay setup call until markup_syntax is set.
+        pass
 
     def test_execute(self, test_syntax):
 
         # Set markup syntax
         markup, header_expand = test_syntax
         self.markup = markup
+
+        # Now we call the actual setup because markup is ready
+        super(MultiSyntaxIntegrationTest, self).setup()
 
         # First, run sanity checks
         success = False

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -8,16 +8,25 @@ class TestDefaultMapping(IntegrationTest):
     viminput = """
     * [ ] test task 1  #{uuid}
     * [ ] test task 2  #{uuid}
+    * [ ] test task 3  #{uuid}
+    * [S] test task 4  #{uuid}
+    * [S] test task 5  #{uuid}
     """
 
     vimoutput = """
     * [X] test task 1  #{uuid}
     * [X] test task 2  #{uuid}
+    * [X] test task 3  #{uuid}
+    * [X] test task 4  #{uuid}
+    * [X] test task 5  #{uuid}
     """
 
     tasks = [
             dict(description="test task 1"),
             dict(description="test task 2"),
+            dict(description="test task 3"),
+            dict(description="test task 4"),
+            dict(description="test task 5"),
     ]
 
     def execute(self):
@@ -34,6 +43,24 @@ class TestDefaultMapping(IntegrationTest):
         sleep(0.5)
 
         self.client.feedkeys(r'\\td')
+        sleep(0.5)
+
+        self.client.normal('3gg')
+        sleep(0.5)
+
+        self.client.feedkeys(r'\<c-space>')
+        sleep(0.5)
+
+        self.client.normal('4gg')
+        sleep(0.5)
+
+        self.client.feedkeys(r'\\td')
+        sleep(0.5)
+
+        self.client.normal('5gg')
+        sleep(0.5)
+
+        self.client.feedkeys(r'\<c-space>')
         sleep(0.5)
 
         for task in self.tasks:


### PR DESCRIPTION
Hi,
I have been working on this #175 for a couple of days now.

The change was pretty straightforward but I had some trouble with the tests. I found out some issues along the way and fixed them.

Here you have the details:
- Actual implementation of the <C-Space> override. Based on the same code used for <CR> override (added test).
- Fix test initialization for multi-syntax tests. Markup was being set _after_ the setup call and thus making the test fail if it was not reset by check_sanity first. Previously it was working because markup syntax was being set to "None" (as a string) and breaking TaskCache initialization **always** for the first time, which made check_sanity to restart the vim instance.
- Fix vimwiki initialization for tests. Init script is not being called by default, so you need to make it explicit.
- Fix travis build. You can see a full run here: https://travis-ci.org/github/aaronfc/taskwiki/builds/673640454.

Regarding the travis build, I decided to include the xvfb inside the docker-image itself so we do not need to rely on it running on travis. A side effect (which I find good) is that now tests run without opening an actual gvim screen and you do not need to run `xhost` command anymore.

A part from that you can see that there are three tests failing. I took a look at them and here you have what I saw:

FAILED tests/test_selected.py::TestInfoActionNotTriggeredByEnterOnLink::test_execute
This is not working and I do not know why. When pressing <CR> VimwikiFollowLink is being called, but it is not doing anything. I have always used vimwiki/taskwiki with Markdown support and this is an empty wikimedia link case. No idea what is happening, but as this is calling VimwikiFollowLink I am assuming it is related to Vimwiki or its configuration.

FAILED tests/test_selected.py::TestSelectAfterBufferSwitch::test_execute
This I think it is because `set filetype=vimwiki` is in fact returning a couple of empty lines. And it is expected to be silent by the test. I would suggest not checking if it is silent or not as it relies on changes on vimwiki itself.

FAILED tests/test_viewport.py::TestViewportsTaskGenerationEmptyFilter::test_execute[markdown]
This I tested and it is in fact not working. If I set an empty filter in markdown (on my local machine using default's master branch) it is not displaying the tasks. We need a fix for this. Shall we create a ticket?


Sorry for the long text, I have been working on this for a couple of days and many things raised. Do not hesitate to discuss any of the above!