### PR TITLE
Adds count viewport setting

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -382,8 +382,28 @@ viewport definition:
 
 ~   == Differently ordered home tasks | project:Home $T ==
 
+------------------
+5.2.4 Limiting number of tasks displayed
+
+By default, taskwiki will present the full list of tasks that match the
+viewport definition.
+
+You can limit the number of tasks listed by using the limit filter:
+
+~   == List only the 5 first tasks | project:Home limit:5 ==
+
+This will instruct taskwiki to limit the list of tasks to 5.
+
+The limit must always come last. For instance, if you are also using a sorting
+identifier:
+
+~   == List only the 5 first tasks | project:Home $T limit:5 ==
+
+The limit keyword will not be passed over to taskwarrior and is consumed only
+only by taskwiki.
+
 --------------------
-5.2.4 Default filter
+5.2.5 Default filter
 
 By default, every viewport filter is extended with the -DELETED and -PARENT
 virtual tags.
@@ -403,7 +423,7 @@ Examples:
 ~   == Home tasks, excluding deleted | project:Home !-DELETED ==
 
 -----------------------
-5.2.5 Meta virtual tags
+5.2.6 Meta virtual tags
 
 Currently there is one meta virtual tag: -VISIBLE. This tag can be used to
 filter out tasks that are displayed elsewhere in the same taskwiki file.
@@ -415,14 +435,14 @@ Example:
 ~    == Work review tasks | project:Work.Review ==
 
 ----------------
-5.2.6 Inspection
+5.2.7 Inspection
 
 You can inspect a given viewport (see what filter and defaults are being used,
 as well as other pieces of information) by using the |:TaskWikiInspect|
 command (or hitting <CR>) over a viewport definition.
 
 -------------------------------------------
-5.2.7 Usage of existing context definitions
+5.2.8 Usage of existing context definitions
 
 If you use the context feature in Taskwarrior, you can easily reference
 definition of any context using the @[context_name] syntax in the viewport's

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -44,43 +44,47 @@ DATE_FORMAT = "(%Y-%m-%d)"
 VIEWPORT = {
     'default':
     re.compile(
-        r'^'                         # Starts at the begging of the line
-        r'(?P<header_start>[=]+)'    # Heading begging
-        r'(?P<name>[^=\|\[\{]*)'     # Name of the viewport, all before the | sign
-                                     # Cannot include '[', '=', '|', and '{'
-        r'\|'                        # Bar
-        r'(?!\|)'                    # (But not two, that would be a preset)
-        r'(?P<filter>[^=\|]*?)'      # Filter
-        r'('                         # Optional defaults
-          r'\|'                      # Bar
-          r'(?P<defaults>[^=\|]+?)'  # Default attrs
+        r'^'                             # Starts at the begging of the line
+        r'(?P<header_start>[=]+)'        # Heading begging
+        r'(?P<name>[^=\|\[\{]*)'         # Name of the viewport, all before the | sign
+                                         # Cannot include '[', '=', '|', and '{'
+        r'\|'                            # Bar
+        r'(?!\|)'                        # (But not two, that would be a preset)
+        r'(?P<filter>[^=\|]*?)'          # Filter
+        r'('                             # Optional defaults
+          r'\|'                          # Bar
+          r'(?P<defaults>[^=\|]+?)'      # Default attrs
         r')?'
-        r'\s*'                       # Any whitespace
-        r'(#(?P<source>[A-Z]))?'     # Optional source indicator
-        r'\s*'                       # Any whitespace
-        r'(\$(?P<sort>[A-Z]))?'      # Optional sort indicator
-        r'\s*'                       # Any whitespace
-        r'[=]+'                      # Header ending
+        r'\s*'                           # Any whitespace
+        r'(#(?P<source>[A-Z]))?'         # Optional source indicator
+        r'\s*'                           # Any whitespace
+        r'(\$(?P<sort>[A-Z]))?'          # Optional sort indicator
+        r'\s*'                           # Any whitespace
+        r'(limit:(?P<count>[0-9]+))?'    # Optional count indicator
+        r'\s*'                           # Any whitespace
+        r'[=]+'                          # Header ending
     ),
     'markdown':
     re.compile(
-        r'^'                         # Starts at the begging of the line
-        r'(?P<header_start>[#]+)'    # Heading begging
-        r'(?P<name>[^#\|\[\{]*)'     # Name of the viewport, all before the | sign
-                                     # Cannot include '[', '#', '|', and '{'
-        r'\|'                        # Bar
-        r'(?!\|)'                    # (But not two, that would be a preset)
-        r'(?P<filter>[^#\|]*?)'      # Filter
-        r'('                         # Optional defaults
-          r'\|'                      # Bar
-          r'(?P<defaults>[^#\|]+?)'  # Default attrs
+        r'^'                             # Starts at the begging of the line
+        r'(?P<header_start>[#]+)'        # Heading begging
+        r'(?P<name>[^#\|\[\{]*)'         # Name of the viewport, all before the | sign
+                                         # Cannot include '[', '#', '|', and '{'
+        r'\|'                            # Bar
+        r'(?!\|)'                        # (But not two, that would be a preset)
+        r'(?P<filter>[^#\|]*?)'          # Filter
+        r'('                             # Optional defaults
+          r'\|'                          # Bar
+          r'(?P<defaults>[^#\|]+?)'      # Default attrs
         r')?'
-        r'\s*'                       # Any whitespace
-        r'(#(?P<source>[A-Z]))?'     # Optional source indicator
-        r'\s*'                       # Any whitespace
-        r'(\$(?P<sort>[A-Z]))?'      # Optional sort indicator
-        r'\s*'                       # Any whitespace
-        r'$'                         # End of line
+        r'\s*'                           # Any whitespace
+        r'(#(?P<source>[A-Z]))?'         # Optional source indicator
+        r'\s*'                           # Any whitespace
+        r'(\$(?P<sort>[A-Z]))?'          # Optional sort indicator
+        r'\s*'                           # Any whitespace
+        r'(limit:(?P<count>[0-9]+))?'    # Optional count indicator
+        r'\s*'                           # Any whitespace
+        r'$'                             # End of line
     )
 }
 

--- a/taskwiki/viewport.py
+++ b/taskwiki/viewport.py
@@ -31,8 +31,17 @@ class ViewPort(object):
 
     meta_tokens = ('-VISIBLE',)
 
-    def __init__(self, line_number, cache, tw,
-                 name, filterstring, defaultstring, sort=None):
+    def __init__(
+        self,
+        line_number,
+        cache,
+        tw,
+        name,
+        filterstring,
+        defaultstring,
+        sort=None,
+        count=-1,
+    ):
         """
         Constructs a ViewPort out of given line.
         """
@@ -57,6 +66,8 @@ class ViewPort(object):
             util.get_var('taskwiki_sort_order') or
             constants.DEFAULT_SORT_ORDER
         )
+
+        self.count = count and int(count) or None
 
     def process_filterstring(self, filterstring, use_presets=True):
         """
@@ -234,8 +245,10 @@ class ViewPort(object):
                 print(u"Sort indicator '{0}' for viewport '{1}' is not defined,"
                        " using default.".format(sort_id, name), sys.stderr)
 
+        count = match.group('count')
+
         self = cls(number, cache, tw, name, filterstring,
-                   defaults, sortstring)
+                   defaults, sortstring, count)
 
         return self
 
@@ -379,3 +392,10 @@ class ViewPort(object):
             self.cache.vwtask[added_at] = vimwikitask
 
         sort.TaskSorter(self.cache, self.tasks, self.sort).execute()
+
+        if self.count is not None:
+            for i in range(
+                self.line_number + self.count,
+                self.line_number + existing_tasks + added_tasks,
+            ):
+                self.cache.remove_line(self.line_number + self.count + 1)

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -545,6 +545,30 @@ class TestViewportsSortedInvalidOrder(MultiSyntaxIntegrationTest):
             "'Work tasks' is not defined, using default.", lines=2)
 
 
+class TestViewportsCount(MultiSyntaxIntegrationTest):
+
+    viminput = """
+    HEADER2(Work tasks | project:Work or project:Home limit:2)
+    """
+
+    vimoutput = """
+    HEADER2(Work tasks | project:Work or project:Home limit:2)
+    * [ ] home task 1 (2015-08-01)  #{uuid}
+    * [ ] work task 1 (2015-08-01)  #{uuid}
+    """
+
+    tasks = [
+        dict(description="home task 1", project="Home", due=datetime(2015,8,1)),
+        dict(description="home task 2", project="Home", due=datetime(2015,8,2)),
+        dict(description="work task 1", project="Work", due=datetime(2015,8,1)),
+        dict(description="work task 2", project="Work", due=datetime(2015,8,2)),
+    ]
+
+    def execute(self):
+        # Generate the tasks
+        self.command("w", regex="written$", lines=1)
+
+
 class TestViewportsVisibleMetaTag(MultiSyntaxIntegrationTest):
 
     viminput = """

--- a/tests/test_viewport_parsing.py
+++ b/tests/test_viewport_parsing.py
@@ -112,6 +112,14 @@ class TestParsingVimwikiTask(object):
         assert port.sort == 'extra'
         assert port.tw == 'extra'
 
+    def test_count(self, test_syntax):
+        example_viewport = "HEADER2(Test | project:Home limit:2)"
+        port = self.process_viewport(example_viewport, test_syntax)
+
+        assert port.taskfilter == list(DEFAULT_VIEWPORT_VIRTUAL_TAGS) + ["(", "project:Home", ")"]
+        assert port.name == "Test"
+        assert port.count == 2
+
     def test_override_default_virtual_tags_neutral(self, test_syntax):
         example_viewport = "HEADER2(Test | project:Home !?DELETED)"
         port = self.process_viewport(example_viewport, test_syntax)


### PR DESCRIPTION
This adds a viewport option to limit the number of tasks shown under the viewport:

```
# Show only 4 tasks | project:my-project *4
```

My use case is that I want to have a "daily tasks" file that gets updated with the top 2 most urgent tasks across all projects. I tried to experiment with the `limit:4` taskwarrior filter but this gets applied during `export` and does not take viewport or any other sorting into account.

I tried to add tests but I am not familiar with writing tests and I have no idea if it is correct.