### PR TITLE
Removes whitespace in front of urgency markers

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -45,7 +45,7 @@ syntax match TaskWikiTaskCompleted containedin=TaskWikiTask contained contains=@
 syntax match TaskWikiTaskDeleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s*\[D\]\s[^#]*/
 syntax match TaskWikiTaskRecurring containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[R\]\s[^#]*/
 syntax match TaskWikiTaskWaiting containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[W\]\s[^#]*/
-syntax match TaskWikiTaskPriority contained /\( !\| !!\| !!!\)\( \)\@=/
+syntax match TaskWikiTaskPriority contained /\( \)\@<=\(!\|!!\|!!!\)\( \)\@=/
 syntax cluster TaskWikiTaskContains add=TaskWikiTaskPriority
 
 " Set concealed parts as really concealed in normal mode, and with cursor over


### PR DESCRIPTION
For some reason, the syntax item for the urgency markers (`!`, `!!`, `!!!`) included a white space in front of it. In some themes, where these markers were highlighted with a red background the space in front, this space shows as red block which is distracting an ugly:

![Screenshot_20200619_105243](https://user-images.githubusercontent.com/11805218/85114857-079fdd80-b21b-11ea-8d6a-7ee646a5a49c.png)

This PR removes the whitespace in the vim syntax of those markers.