### PR TITLE
settings: Remember cursor position in the view

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -56,7 +56,7 @@ endif
 " Configure custom FoldText function
 " Altered version of the VimwikiFoldText
 setlocal foldmethod=syntax
-setlocal viewoptions=folds
+setlocal viewoptions-=options
 
 function! TaskwikiFoldText()
   let line = getline(v:foldstart)


### PR DESCRIPTION
Commit 9f3a52e73b meant to only disable remembering options, but it
ended up disabling remembering of cursor position as well. The cursor is
still restored by last-position-jump (see usr_05.txt) if one has that in
their vimrc, but whenever there are any folds in the view, restoring
these folds resets the cursor again.

Not disabling saving of cursor position fixes this in the default
configuration and lets the user tweak viewoptions however they like.