### PR TITLE
cache: Mark buffer as modified on push

### DIFF
--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -22,10 +22,12 @@ class BufferProxy(object):
 
     def push(self):
         with util.current_line_preserved():
+            buffer = util.get_buffer(self.buffer_number)
             # Only set the buffer contents if the data is changed.
             # Avoids extra undo events with empty diff.
-            if util.get_buffer(self.buffer_number)[:] != self.data:
-                util.get_buffer(self.buffer_number)[:] = self.data
+            if buffer[:] != self.data:
+                buffer[:] = self.data
+                buffer.options['modified'] = True
 
     def __getitem__(self, index):
         try:

--- a/tests/test_selected.py
+++ b/tests/test_selected.py
@@ -1323,7 +1323,6 @@ class TestSelectAfterBufferSwitch(IntegrationTest):
     def execute(self):
         self.command('w', silent=False)
         self.command('split testwiki2.txt', silent=False)
-        self.command('set filetype=vimwiki')
         self.command('q!')
         self.client.normal('1gg')
         self.command("TaskWikiMod project:Home", regex="Modified 1 task.")


### PR DESCRIPTION
When a (task)wiki file is opened, viewports are refreshed but the buffer is
not marked as modified and therefore a subsequent :xa doesn't update the
file. This is, IMO, undesired.

vim documentation for the 'modified' option:

> This option is not set when a change is made to the buffer as the
> result of a BufNewFile, BufRead/BufReadPost, BufWritePost,
> FileAppendPost or VimLeave autocommand event.  See |gzip-example| for
> an explanation.

(plus one small fix forgotten in 7d5b902c899fd59e0ce02bef665d5b7e69b1b16e that I discovered while writing a test)