### PR TITLE
vwtask: Refactor apply_defaults

### DIFF
--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -360,27 +360,26 @@ class VimwikiTask(object):
     def apply_defaults(self):
         from taskwiki import viewport, preset
 
+        # Find first parent header or viewport
+        header, port = None, None
         for i in reversed(range(0, self['line_number'])):
             header = preset.PresetHeader.from_line(i, self.cache)
+            port = viewport.ViewPort.from_line(i, self.cache)
+            if header or port:
+                break
 
-            if not header:
-                continue
-
+        if header:
             # Use defaults from the preset header hierarchy
             self.update(header.defaults)
 
-            port = viewport.ViewPort.from_line(i, self.cache)
-            if port:
-                # The task should have the same source as the viewport has
-                self.tw = port.tw
-                self.task.backend = port.tw
+        if port:
+            # The task should have the same source as the viewport has
+            self.tw = port.tw
+            self.task.backend = port.tw
 
-                # Any defaults specified should be inherited
-                self.update(port.defaults)
+            # Any defaults specified should be inherited
+            self.update(port.defaults)
 
-                # If port was detected, break the search
-
-            break
 
     def update(self, defaults):
         """


### PR DESCRIPTION
5bf0c89ae885f41448f321750a09854f3f0a0dd9 left a misleading comment in
the code:

                # If port was detected, break the search
    
            break

Refactor the code to make it clearer what's going on: we're looking for
the first parent header/preset/viewport of this task, and therefore we
always break. By separating the search and processing of the found
header/preset/viewport, we avoid the confusion.

Related: https://github.com/tools-life/taskwiki/pull/288