### PR TITLE
Replace ignoring all uppercase tags with vtags

### DIFF
--- a/taskwiki/util.py
+++ b/taskwiki/util.py
@@ -88,7 +88,8 @@ def tw_args_to_kwargs(args):
         elif arg.startswith('+'):
             value = arg[1:]
             # Ignore virtual tags
-            if not value.isupper():
+            vtags = ["BLOCKED", "UNBLOCKED", "BLOCKING", "DUE", "DUETODAY", "TODAY", "OVERDUE", "WEEK", "MONTH", "QUARTER", "YEAR", "ACTIVE", "SCHEDULED", "PARENT", "CHILD", "UNTIL", "WAITING", "ANNOTATED", "READY", "YESTERDAY", "TOMORROW", "TAGGED", "PENDING", "COMPLETED", "DELETED", "UDA", "ORPHAN", "PRIORITY", "PROJECT", "LATEST"]
+            if not value in vtags:
                 output.setdefault('tags', []).append(value)
             # Ignore tag removal
 


### PR DESCRIPTION
This commit explicitly defines a list of virtual tags as given in the
link given below at this point in time. This includes virtual tags
defined for version 2.6.0 (+QUARTER).

https://taskwarrior.org/docs/tags.html