### PR TITLE
ftplugin: Fixes, cleanups

### DIFF
--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -31,6 +31,10 @@ if !exists("g:did_python_taskwiki")
   let g:did_python_taskwiki = 1
 endif
 
+" Global update commands
+execute "command! -buffer -nargs=* TaskWikiBufferSave :"      . g:taskwiki_py . "WholeBuffer.update_to_tw()"
+execute "command! -buffer -nargs=* TaskWikiBufferLoad :"      . g:taskwiki_py . "WholeBuffer.update_from_tw()"
+
 augroup taskwiki
     autocmd! * <buffer>
     " Update to TW upon saving
@@ -45,15 +49,11 @@ augroup taskwiki
 
     " Refresh on load (if possible, after loadview to preserve folds)
     if has('patch-8.1.1113') || has('nvim-0.4.0')
-      execute "autocmd BufWinEnter <buffer> ++once :" . g:taskwiki_py . "WholeBuffer.update_from_tw()"
+      autocmd BufWinEnter <buffer> ++once TaskWikiBufferLoad
     else
-      execute g:taskwiki_py . "WholeBuffer.update_from_tw()"
+      TaskWikiBufferLoad
     endif
 augroup END
-
-" Global update commands
-execute "command! -buffer -nargs=* TaskWikiBufferSave :"      . g:taskwiki_py . "WholeBuffer.update_to_tw()"
-execute "command! -buffer -nargs=* TaskWikiBufferLoad :"      . g:taskwiki_py . "WholeBuffer.update_from_tw()"
 
 " Split reports commands
 execute "command! -buffer -nargs=* TaskWikiProjects :"        . g:taskwiki_py . "SplitProjects(<q-args>).execute()"

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -28,16 +28,16 @@ let s:plugin_path = escape(expand('<sfile>:p:h:h:h'), '\')
 execute g:taskwiki_pyfile . s:plugin_path . '/taskwiki/main.py'
 
 augroup taskwiki
-    autocmd!
+    autocmd! * <buffer>
     " Update to TW upon saving
-    execute "autocmd BufWrite *.".expand('%:e')." TaskWikiBufferSave"
+    autocmd BufWrite <buffer> TaskWikiBufferSave
     " Save and load the view to preserve folding, if desired
     if !exists('g:taskwiki_dont_preserve_folds')
-      execute "autocmd BufWinLeave *.".expand('%:e')." mkview"
-      execute "autocmd BufWinEnter *.".expand('%:e')." silent! loadview"
-      execute "autocmd BufWinEnter *.".expand('%:e')." silent! doautocmd SessionLoadPost *.".expand('%:e')
+      autocmd BufWinLeave <buffer> mkview
+      autocmd BufWinEnter <buffer> silent! loadview
+      autocmd BufWinEnter <buffer> silent! doautocmd SessionLoadPost
     endif
-    execute "autocmd BufEnter *.".expand('%:e')." :" . g:taskwiki_py . "cache.load_current().reset()"
+    execute "autocmd BufEnter <buffer> :" . g:taskwiki_py . "cache.load_current().reset()"
 augroup END
 
 " Global update commands

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -21,11 +21,17 @@ if exists("g:taskwiki_disable")
   finish
 endif
 
-" Determine the plugin path
-let s:plugin_path = escape(expand('<sfile>:p:h:h:h'), '\')
+if !exists("g:did_python_taskwiki")
+  " Determine the plugin path
+  let s:plugin_path = escape(expand('<sfile>:p:h:h:h'), '\')
 
-" Execute the main body of taskwiki source
-execute g:taskwiki_pyfile . s:plugin_path . '/taskwiki/main.py'
+  " Execute the main body of taskwiki source
+  execute g:taskwiki_pyfile . s:plugin_path . '/taskwiki/main.py'
+
+  let g:did_python_taskwiki = 1
+endif
+
+execute g:taskwiki_py . "WholeBuffer.update_from_tw()"
 
 augroup taskwiki
     autocmd! * <buffer>

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -31,8 +31,6 @@ if !exists("g:did_python_taskwiki")
   let g:did_python_taskwiki = 1
 endif
 
-execute g:taskwiki_py . "WholeBuffer.update_from_tw()"
-
 augroup taskwiki
     autocmd! * <buffer>
     " Update to TW upon saving
@@ -44,6 +42,13 @@ augroup taskwiki
       autocmd BufWinEnter <buffer> silent! doautocmd SessionLoadPost
     endif
     execute "autocmd BufEnter <buffer> :" . g:taskwiki_py . "cache.load_current().reset()"
+
+    " Refresh on load (if possible, after loadview to preserve folds)
+    if has('patch-8.1.1113') || has('nvim-0.4.0')
+      execute "autocmd BufWinEnter <buffer> ++once :" . g:taskwiki_py . "WholeBuffer.update_from_tw()"
+    else
+      execute g:taskwiki_py . "WholeBuffer.update_from_tw()"
+    endif
 augroup END
 
 " Global update commands

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -41,44 +41,44 @@ augroup taskwiki
 augroup END
 
 " Global update commands
-execute "command! -nargs=* TaskWikiBufferSave :"      . g:taskwiki_py . "WholeBuffer.update_to_tw()"
-execute "command! -nargs=* TaskWikiBufferLoad :"      . g:taskwiki_py . "WholeBuffer.update_from_tw()"
+execute "command! -buffer -nargs=* TaskWikiBufferSave :"      . g:taskwiki_py . "WholeBuffer.update_to_tw()"
+execute "command! -buffer -nargs=* TaskWikiBufferLoad :"      . g:taskwiki_py . "WholeBuffer.update_from_tw()"
 
 " Split reports commands
-execute "command! -nargs=* TaskWikiProjects :"        . g:taskwiki_py . "SplitProjects(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiProjectsSummary :" . g:taskwiki_py . "SplitSummary(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiBurndownDaily :"   . g:taskwiki_py . "SplitBurndownDaily(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiBurndownMonthly :" . g:taskwiki_py . "SplitBurndownMonthly(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiBurndownWeekly :"  . g:taskwiki_py . "SplitBurndownWeekly(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiCalendar :"        . g:taskwiki_py . "SplitCalendar(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiGhistoryAnnual :"  . g:taskwiki_py . "SplitGhistoryAnnual(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiGhistoryMonthly :" . g:taskwiki_py . "SplitGhistoryMonthly(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiHistoryAnnual :"   . g:taskwiki_py . "SplitHistoryAnnual(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiHistoryMonthly :"  . g:taskwiki_py . "SplitHistoryMonthly(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiStats :"           . g:taskwiki_py . "SplitStats(<q-args>).execute()"
-execute "command! -nargs=* TaskWikiTags :"            . g:taskwiki_py . "SplitTags(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiProjects :"        . g:taskwiki_py . "SplitProjects(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiProjectsSummary :" . g:taskwiki_py . "SplitSummary(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiBurndownDaily :"   . g:taskwiki_py . "SplitBurndownDaily(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiBurndownMonthly :" . g:taskwiki_py . "SplitBurndownMonthly(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiBurndownWeekly :"  . g:taskwiki_py . "SplitBurndownWeekly(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiCalendar :"        . g:taskwiki_py . "SplitCalendar(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiGhistoryAnnual :"  . g:taskwiki_py . "SplitGhistoryAnnual(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiGhistoryMonthly :" . g:taskwiki_py . "SplitGhistoryMonthly(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiHistoryAnnual :"   . g:taskwiki_py . "SplitHistoryAnnual(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiHistoryMonthly :"  . g:taskwiki_py . "SplitHistoryMonthly(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiStats :"           . g:taskwiki_py . "SplitStats(<q-args>).execute()"
+execute "command! -buffer -nargs=* TaskWikiTags :"            . g:taskwiki_py . "SplitTags(<q-args>).execute()"
 
 " Commands that operate on tasks in the buffer
-execute "command! -range TaskWikiInfo :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().info()"
-execute "command! -range TaskWikiEdit :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().edit()"
-execute "command! -range TaskWikiLink :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().link()"
-execute "command! -range TaskWikiGrid :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().grid()"
-execute "command! -range TaskWikiDelete :<line1>,<line2>" . g:taskwiki_py . "SelectedTasks().delete()"
-execute "command! -range TaskWikiStart :<line1>,<line2>"  . g:taskwiki_py . "SelectedTasks().start()"
-execute "command! -range TaskWikiStop :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().stop()"
-execute "command! -range TaskWikiDone :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().done()"
-execute "command! -range TaskWikiRedo :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().redo()"
+execute "command! -buffer -range TaskWikiInfo :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().info()"
+execute "command! -buffer -range TaskWikiEdit :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().edit()"
+execute "command! -buffer -range TaskWikiLink :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().link()"
+execute "command! -buffer -range TaskWikiGrid :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().grid()"
+execute "command! -buffer -range TaskWikiDelete :<line1>,<line2>" . g:taskwiki_py . "SelectedTasks().delete()"
+execute "command! -buffer -range TaskWikiStart :<line1>,<line2>"  . g:taskwiki_py . "SelectedTasks().start()"
+execute "command! -buffer -range TaskWikiStop :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().stop()"
+execute "command! -buffer -range TaskWikiDone :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().done()"
+execute "command! -buffer -range TaskWikiRedo :<line1>,<line2>"   . g:taskwiki_py . "SelectedTasks().redo()"
 
-execute "command! -range -nargs=* TaskWikiSort :<line1>,<line2>"     . g:taskwiki_py . "SelectedTasks().sort(<q-args>)"
-execute "command! -range -nargs=* TaskWikiMod :<line1>,<line2>"      . g:taskwiki_py . "SelectedTasks().modify(<q-args>)"
-execute "command! -range -nargs=* TaskWikiAnnotate :<line1>,<line2>" . g:taskwiki_py . "SelectedTasks().annotate(<q-args>)"
+execute "command! -buffer -range -nargs=* TaskWikiSort :<line1>,<line2>"     . g:taskwiki_py . "SelectedTasks().sort(<q-args>)"
+execute "command! -buffer -range -nargs=* TaskWikiMod :<line1>,<line2>"      . g:taskwiki_py . "SelectedTasks().modify(<q-args>)"
+execute "command! -buffer -range -nargs=* TaskWikiAnnotate :<line1>,<line2>" . g:taskwiki_py . "SelectedTasks().annotate(<q-args>)"
 
 " Interactive commands
-execute "command! -range TaskWikiChooseProject :<line1>,<line2>"     . g:taskwiki_py . "ChooseSplitProjects('global').execute()"
-execute "command! -range TaskWikiChooseTag :<line1>,<line2>"         . g:taskwiki_py . "ChooseSplitTags('global').execute()"
+execute "command! -buffer -range TaskWikiChooseProject :<line1>,<line2>"     . g:taskwiki_py . "ChooseSplitProjects('global').execute()"
+execute "command! -buffer -range TaskWikiChooseTag :<line1>,<line2>"         . g:taskwiki_py . "ChooseSplitTags('global').execute()"
 
 " Meta commands
-execute "command! TaskWikiInspect :" . g:taskwiki_py . "Meta().inspect_viewport()"
+execute "command! -buffer TaskWikiInspect :" . g:taskwiki_py . "Meta().inspect_viewport()"
 
 " Disable <CR> as VimwikiFollowLink
 if !hasmapto('<Plug>VimwikiFollowLink')

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -32,7 +32,7 @@ class WholeBuffer(object):
         Updates all the incomplete tasks in the vimwiki file if the info from TW is different.
         """
 
-        c = cache()
+        c = cache.load_current()
         c.reset()
         c.load_tasks()
         c.load_presets()
@@ -51,7 +51,7 @@ class WholeBuffer(object):
         Updates all tasks that differ from their TaskWarrior representation.
         """
 
-        c = cache()
+        c = cache.load_current()
         c.reset()
         c.load_tasks()
         c.load_presets()
@@ -637,6 +637,5 @@ class ChooseSplitTags(CallbackSplitMixin, SplitTags):
 
 
 if __name__ == '__main__':
-    WholeBuffer.update_from_tw()
     Meta().integrate_tagbar()
     Meta().set_proper_colors()

--- a/tests/test_ftplugin.py
+++ b/tests/test_ftplugin.py
@@ -1,0 +1,18 @@
+import os
+from tests.base import IntegrationTest
+
+
+class TestCachePreserved(IntegrationTest):
+
+    def execute(self):
+        testfile2 = os.path.join(self.dir, "testwiki2.txt")
+
+        self.command("w", regex="written$", lines=1)
+        self.command("w {}".format(testfile2), regex="written$", lines=1)
+
+        self.client.edit(testfile2)
+
+        # check that all buffers have a cache entry
+        cache_keys = self.client.eval('py3eval("sorted(cache.caches.keys())")')
+        buffers = self.client.eval('py3eval("sorted(b.number for b in vim.buffers)")')
+        assert cache_keys == buffers

--- a/tests/test_splits.py
+++ b/tests/test_splits.py
@@ -277,6 +277,9 @@ class TestSplitReplacement(IntegrationTest):
         assert self.py("print(vim.current.buffer)", silent=False).startswith("<buffer burndown.daily")
         assert "Daily Burndown" in self.read_buffer()[0]
 
+        # switch back to taskwiki buffer
+        self.client.feedkeys("\\<C-W>p")
+
         self.command("TaskWikiBurndownDaily")
         assert self.py("print(vim.current.buffer)", silent=False).startswith("<buffer burndown.daily")
         assert "Daily Burndown" in self.read_buffer()[0]


### PR DESCRIPTION
Three important fixes:

1. Do not reload `main.py` and thus discard the entire CacheRegistry
   when switching wiki pages.

2. Do not reset (and thus reorder) autocommands when switching wiki
   pages. Also, do not trigger autocommands outside of wikis.

3. Restore view (and thus folds) before updating the buffer.

Plus some cleanups/refactors. Details in commit messages.