### PR TITLE
vwtags: Add tests and fix several bugs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
-source = taskwiki
+source = taskwiki, extra
 data_file = /tmp/taskwiki-coverage/.coverage

--- a/extra/vwtags.py
+++ b/extra/vwtags.py
@@ -1,17 +1,41 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import print_function
+
+help_text = """
+Extracts tags from Vimwiki files. Useful for the Tagbar plugin.
+
+Usage:
+Install Tagbar (http://majutsushi.github.io/tagbar/). Then, put this file
+anywhere and add the following to your .vimrc:
+
+let g:tagbar_type_vimwiki = {
+          \   'ctagstype':'vimwiki'
+          \ , 'kinds':['h:header']
+          \ , 'sro':'&&&'
+          \ , 'kind2scope':{'h':'header'}
+          \ , 'sort':0
+          \ , 'ctagsbin':'/path/to/vwtags.py'
+          \ , 'ctagsargs': 'default'
+          \ }
+
+The value of ctagsargs must be one of 'default', 'markdown' or 'media',
+whatever syntax you use. However, if you use multiple wikis with different
+syntaxes, you can, as a workaround, use the value 'all' instead. Then, Tagbar
+will show markdown style headers as well as default/mediawiki style headers,
+but there might be erroneously shown headers.
+"""
 
 import sys
 import re
 
 if len(sys.argv) < 3:
+    print(help_text)
     exit()
 
 syntax = sys.argv[1]
 filename = sys.argv[2]
-
 rx_default_media = r"^\s*(={1,6})([^=].*[^=])\1\s*$"
 rx_markdown = r"^\s*(#{1,6})([^#].*)$"
 
@@ -29,7 +53,6 @@ try:
 except:
     exit()
 
-result = []
 state = [""]*6
 for lnum, line in enumerate(file_content):
 
@@ -42,9 +65,9 @@ for lnum, line in enumerate(file_content):
     match_tag = match_header.group(2) or match_header.group(4)
 
     cur_lvl = len(match_lvl)
-    cur_tag = match_tag.split('|')[0].strip()
+    cur_tag = match_tag.strip()
     cur_searchterm = "^" + match_header.group(0).rstrip("\r\n") + "$"
-    cur_kind = "h" if not '|' in line else "v"
+    cur_kind = "h"
 
     state[cur_lvl-1] = cur_tag
     for i in range(cur_lvl, 6):
@@ -55,18 +78,5 @@ for lnum, line in enumerate(file_content):
     if scope:
         scope = "\theader:" + scope
 
-    result.append([cur_tag, filename, cur_searchterm, cur_kind, str(lnum+1), scope])
-
-for i in range(len(result)):
-    if i != len(result) - 1:
-        if len(result[i+1][5]) <= len(result[i][5]) and len(result[i][5]) != 0:
-            result[i][3] = 'i'
-
     print('{0}\t{1}\t/{2}/;"\t{3}\tline:{4}{5}'.format(
-        result[i][0],
-        result[i][1],
-        result[i][2],
-        result[i][3],
-        result[i][4],
-        result[i][5],
-        ))
+        cur_tag, filename, cur_searchterm, cur_kind, str(lnum+1), scope))

--- a/extra/vwtags.py
+++ b/extra/vwtags.py
@@ -1,35 +1,43 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import sys
+import os
 import re
+import sys
 
-rx_default_media = r"^\s*(={1,6})([^=].*[^=])\1\s*$"
-rx_markdown = r"^\s*(#{1,6})([^#].*)$"
+if __name__ == '__main__':
+    path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    sys.path.insert(0, path)
+
+from taskwiki import regexp
+
+
+def match_header(line, syntax):
+    m = re.search(regexp.VIEWPORT[syntax], line)
+    if m:
+        return m
+
+    m = re.search(regexp.PRESET[syntax], line)
+    if m:
+        return m
+
+    m = re.search(regexp.HEADER[syntax], line)
+    if m:
+        return m
+
+    return None
 
 
 def process(file_content, filename, syntax):
-    if syntax in ("default", "media"):
-        rx_header = re.compile(rx_default_media)
-    elif syntax == "markdown":
-        rx_header = re.compile(rx_markdown)
-    else:
-        rx_header = re.compile(rx_default_media + "|" + rx_markdown)
-
     state = [""]*6
     for lnum, line in enumerate(file_content):
-
-        match_header = rx_header.match(line)
-
-        if not match_header:
+        m = match_header(line, syntax)
+        if not m:
             continue
 
-        match_lvl = match_header.group(1) or match_header.group(3)
-        match_tag = match_header.group(2) or match_header.group(4)
-
-        cur_lvl = len(match_lvl)
-        cur_tag = match_tag.strip()
-        cur_searchterm = "^" + match_header.group(0).rstrip("\r\n") + "$"
+        cur_lvl = len(m.group('header_start'))
+        cur_tag = m.group('name').strip()
+        cur_searchterm = "^" + m.group(0).rstrip("\r\n") + "$"
         cur_kind = "h"
 
         state[cur_lvl-1] = cur_tag

--- a/extra/vwtags.py
+++ b/extra/vwtags.py
@@ -1,37 +1,10 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
-help_text = """
-Extracts tags from Vimwiki files. Useful for the Tagbar plugin.
-
-Usage:
-Install Tagbar (http://majutsushi.github.io/tagbar/). Then, put this file
-anywhere and add the following to your .vimrc:
-
-let g:tagbar_type_vimwiki = {
-          \   'ctagstype':'vimwiki'
-          \ , 'kinds':['h:header']
-          \ , 'sro':'&&&'
-          \ , 'kind2scope':{'h':'header'}
-          \ , 'sort':0
-          \ , 'ctagsbin':'/path/to/vwtags.py'
-          \ , 'ctagsargs': 'default'
-          \ }
-
-The value of ctagsargs must be one of 'default', 'markdown' or 'media',
-whatever syntax you use. However, if you use multiple wikis with different
-syntaxes, you can, as a workaround, use the value 'all' instead. Then, Tagbar
-will show markdown style headers as well as default/mediawiki style headers,
-but there might be erroneously shown headers.
-"""
-
 import sys
 import re
 
 if len(sys.argv) < 3:
-    print(help_text)
     exit()
 
 syntax = sys.argv[1]

--- a/extra/vwtags.py
+++ b/extra/vwtags.py
@@ -4,52 +4,60 @@
 import sys
 import re
 
-if len(sys.argv) < 3:
-    exit()
-
-syntax = sys.argv[1]
-filename = sys.argv[2]
 rx_default_media = r"^\s*(={1,6})([^=].*[^=])\1\s*$"
 rx_markdown = r"^\s*(#{1,6})([^#].*)$"
 
-if syntax in ("default", "media"):
-    rx_header = re.compile(rx_default_media)
-elif syntax == "markdown":
-    rx_header = re.compile(rx_markdown)
-else:
-    rx_header = re.compile(rx_default_media + "|" + rx_markdown)
 
-file_content = []
-try:
-    with open(filename, "r") as vim_buffer:
-        file_content = vim_buffer.readlines()
-except:
-    exit()
+def process(file_content, filename, syntax):
+    if syntax in ("default", "media"):
+        rx_header = re.compile(rx_default_media)
+    elif syntax == "markdown":
+        rx_header = re.compile(rx_markdown)
+    else:
+        rx_header = re.compile(rx_default_media + "|" + rx_markdown)
 
-state = [""]*6
-for lnum, line in enumerate(file_content):
+    state = [""]*6
+    for lnum, line in enumerate(file_content):
 
-    match_header = rx_header.match(line)
+        match_header = rx_header.match(line)
 
-    if not match_header:
-        continue
+        if not match_header:
+            continue
 
-    match_lvl = match_header.group(1) or match_header.group(3)
-    match_tag = match_header.group(2) or match_header.group(4)
+        match_lvl = match_header.group(1) or match_header.group(3)
+        match_tag = match_header.group(2) or match_header.group(4)
 
-    cur_lvl = len(match_lvl)
-    cur_tag = match_tag.strip()
-    cur_searchterm = "^" + match_header.group(0).rstrip("\r\n") + "$"
-    cur_kind = "h"
+        cur_lvl = len(match_lvl)
+        cur_tag = match_tag.strip()
+        cur_searchterm = "^" + match_header.group(0).rstrip("\r\n") + "$"
+        cur_kind = "h"
 
-    state[cur_lvl-1] = cur_tag
-    for i in range(cur_lvl, 6):
-        state[i] = ""
+        state[cur_lvl-1] = cur_tag
+        for i in range(cur_lvl, 6):
+            state[i] = ""
 
-    scope = "&&&".join(
-            [state[i] for i in range(0, cur_lvl-1) if state[i] != ""])
-    if scope:
-        scope = "\theader:" + scope
+        scope = "&&&".join(
+                [state[i] for i in range(0, cur_lvl-1) if state[i] != ""])
+        if scope:
+            scope = "\theader:" + scope
 
-    print('{0}\t{1}\t/{2}/;"\t{3}\tline:{4}{5}'.format(
-        cur_tag, filename, cur_searchterm, cur_kind, str(lnum+1), scope))
+        yield('{0}\t{1}\t/{2}/;"\t{3}\tline:{4}{5}'.format(
+            cur_tag, filename, cur_searchterm, cur_kind, str(lnum+1), scope))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        exit()
+
+    syntax = sys.argv[1]
+    filename = sys.argv[2]
+
+    file_content = []
+    try:
+        with open(filename, "r") as vim_buffer:
+            file_content = vim_buffer.readlines()
+    except:
+        exit()
+
+    for output in process(file_content, filename, syntax):
+        print(output)

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -346,9 +346,9 @@ class Meta(object):
         if tagbar_available:
             vim.vars['tagbar_type_vimwiki'] = {
                 'ctagstype': 'default',
-                'kinds': ['h:header'],
+                'kinds': ['h:header', 'p:preset', 'v:viewport'],
                 'sro': '&&&',
-                'kind2scope': {'h': 'header'},
+                'kind2scope': {'h': 'header', 'p': 'preset', 'v': 'viewport'},
                 'sort': 0,
                 'ctagsbin': os.path.join(BASE_DIR, 'extra/vwtags.py'),
                 'ctagsargs': 'default'

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -346,9 +346,9 @@ class Meta(object):
         if tagbar_available:
             vim.vars['tagbar_type_vimwiki'] = {
                 'ctagstype': 'default',
-                'kinds': ['h:header', 'i:inside', 'v:viewport'],
+                'kinds': ['h:header'],
                 'sro': '&&&',
-                'kind2scope': {'h':'header', 'v':'viewport'},
+                'kind2scope': {'h': 'header'},
                 'sort': 0,
                 'ctagsbin': os.path.join(BASE_DIR, 'extra/vwtags.py'),
                 'ctagsargs': 'default'

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -45,7 +45,7 @@ VIEWPORT = {
     'default':
     re.compile(
         r'^'                         # Starts at the begging of the line
-        r'[=]+'                      # Heading begging
+        r'(?P<header_start>[=]+)'    # Heading begging
         r'(?P<name>[^=\|\[\{]*)'     # Name of the viewport, all before the | sign
                                      # Cannot include '[', '=', '|', and '{'
         r'\|'                        # Bar
@@ -65,7 +65,7 @@ VIEWPORT = {
     'markdown':
     re.compile(
         r'^'                         # Starts at the begging of the line
-        r'[#]+'                      # Heading begging
+        r'(?P<header_start>[#]+)'    # Heading begging
         r'(?P<name>[^#\|\[\{]*)'     # Name of the viewport, all before the | sign
                                      # Cannot include '[', '#', '|', and '{'
         r'\|'                        # Bar
@@ -89,7 +89,7 @@ HEADER = {
     re.compile(
         r'^'                         # Starts at the beginning of the line
         r'(?P<header_start>[=]+)'    # With a positive number of =
-        r'[^=]+'                     # Character other than =
+        r'(?P<name>[^=]+)'           # Character other than =
         r'[=]+'                      # Positive number of =, closing the header
         r'\s*'                       # Allow trailing whitespace
     ),
@@ -97,7 +97,7 @@ HEADER = {
     re.compile(
         r'^'                         # Starts at the beginning of the line
         r'(?P<header_start>[#]+)'    # With a positive number of #
-        r'[^#]+'                     # Character other than #
+        r'(?P<name>[^#]+)'           # Character other than #
     )
 }
 
@@ -106,7 +106,7 @@ PRESET = {
     re.compile(
         r'^'                         # Starts at the beginning of the line
         r'(?P<header_start>[=]+)'    # With a positive number of =
-        r'([^=\|\[\{]*)'             # Heading caption, everything up to ||
+        r'(?P<name>[^=\|\[\{]*)'     # Heading caption, everything up to ||
                                      # Cannot include '[', '=', '|, and '{'
         r'\|\|'                      # Delimiter
         r'(?P<filter>[^=\|]+?)'      # Filter preset
@@ -121,7 +121,7 @@ PRESET = {
     re.compile(
         r'^'                         # Starts at the beginning of the line
         r'(?P<header_start>[#]+)'    # With a positive number of #
-        r'([^#\|\[\{]*)'             # Heading caption, everything up to ||
+        r'(?P<name>[^#\|\[\{]*)'     # Heading caption, everything up to ||
                                      # Cannot include '[', '#', '|, and '{'
         r'\|\|'                      # Delimiter
         r'(?P<filter>[^#\|]+?)'      # Filter preset

--- a/tests/test_vwtags.py
+++ b/tests/test_vwtags.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+import re
+import textwrap
+from itertools import zip_longest
+from extra import vwtags
+
+
+class TagsTest(object):
+    wiki_input = None
+    expected_output = None
+    markup = 'default'
+
+    def test_execute(self):
+        wiki_input = textwrap.dedent(self.wiki_input).splitlines()
+        got_output = list(vwtags.process(wiki_input, "file.wiki", self.markup))
+
+        if isinstance(self.expected_output, str):
+            expected_output = textwrap.dedent(self.expected_output).splitlines()
+        else:
+            expected_output = self.expected_output
+
+        explanation = {'got_output': got_output, 'expected_output': expected_output}
+        for line, (got, expected) in enumerate(zip_longest(got_output, expected_output)):
+            explanation['line'] = line
+            if hasattr(expected, 'search'):
+                assert expected.search(got) is not None, explanation
+            else:
+                assert got == expected, explanation
+
+
+class MultiSyntaxTagsTest(TagsTest):
+
+    def test_execute(self, test_syntax):
+        markup, header_expand = test_syntax
+        self.markup = markup
+        self.wiki_input = header_expand(self.wiki_input)
+
+        super(MultiSyntaxTagsTest, self).test_execute()
+
+
+class TestTagsEmpty(TagsTest):
+    wiki_input = ""
+    expected_output = ""
+
+
+class TestTagsBasic(MultiSyntaxTagsTest):
+    wiki_input = """\
+    HEADER1(a)
+    HEADER2(b)
+    HEADER2(c)
+    HEADER3(d)
+    not HEADER2(e)
+    HEADER2(f)
+    HEADER1(g)
+    HEADER3(h)
+    """
+
+    expected_output = [
+        re.compile(r"^a	file.wiki	/.*/;\"	h	line:1$"),
+        re.compile(r"^b	file.wiki	/.*/;\"	h	line:2	header:a$"),
+        re.compile(r"^c	file.wiki	/.*/;\"	h	line:3	header:a$"),
+        re.compile(r"^d	file.wiki	/.*/;\"	h	line:4	header:a&&&c$"),
+        re.compile(r"^f	file.wiki	/.*/;\"	h	line:6	header:a$"),
+        re.compile(r"^g	file.wiki	/.*/;\"	h	line:7$"),
+        re.compile(r"^h	file.wiki	/.*/;\"	h	line:8	header:g$"),
+    ]

--- a/tests/test_vwtags.py
+++ b/tests/test_vwtags.py
@@ -65,3 +65,31 @@ class TestTagsBasic(MultiSyntaxTagsTest):
         re.compile(r"^g	file.wiki	/.*/;\"	h	line:7$"),
         re.compile(r"^h	file.wiki	/.*/;\"	h	line:8	header:g$"),
     ]
+
+
+class TestTagsViewportsPresets(MultiSyntaxTagsTest):
+    wiki_input = """\
+    HEADER1(a)
+    HEADER2(b | +DUETODAY)
+    HEADER2(c || +home)
+    HEADER3(d | +OVERDUE | due:today)
+    """
+
+    expected_output = [
+        re.compile(r"^a	file.wiki	/.*/;\"	h	line:1$"),
+        re.compile(r"^b	file.wiki	/.*/;\"	h	line:2	header:a$"),
+        re.compile(r"^c	file.wiki	/.*/;\"	h	line:3	header:a$"),
+        re.compile(r"^d	file.wiki	/.*/;\"	h	line:4	header:a&&&c$"),
+    ]
+
+
+class TestTagsVimwikiLinks(TagsTest):
+    wiki_input = """\
+    = [[link]] =
+    == [[li|nk]] ==
+    """
+
+    expected_output = """\
+    [[link]]	file.wiki	/^= [[link]] =$/;"	h	line:1
+    [[li|nk]]	file.wiki	/^== [[li|nk]] ==$/;"	h	line:2	header:[[link]]
+    """

--- a/tests/test_vwtags.py
+++ b/tests/test_vwtags.py
@@ -77,9 +77,9 @@ class TestTagsViewportsPresets(MultiSyntaxTagsTest):
 
     expected_output = [
         re.compile(r"^a	file.wiki	/.*/;\"	h	line:1$"),
-        re.compile(r"^b	file.wiki	/.*/;\"	h	line:2	header:a$"),
-        re.compile(r"^c	file.wiki	/.*/;\"	h	line:3	header:a$"),
-        re.compile(r"^d	file.wiki	/.*/;\"	h	line:4	header:a&&&c$"),
+        re.compile(r"^b	file.wiki	/.*/;\"	v	line:2	header:a$"),
+        re.compile(r"^c	file.wiki	/.*/;\"	p	line:3	header:a$"),
+        re.compile(r"^d	file.wiki	/.*/;\"	v	line:4	preset:a&&&c$"),
     ]
 
 


### PR DESCRIPTION
* headers containing `[[vimwiki|links]]` were incorrectly marked as viewports
* headers/viewports nested below such headers weren't correctly nested in tagbar as they used `header:` to refer to their parent scope
* presets were marked as viewports, and viewports nested under presets didn't correctly nest for the same reason as above
* the logic for marking headers/viewports as `i:inside` is incorrect (based on length of headers ???), and the motivation for it is unclear, so it's dropped