### PR TITLE
ci: Simplify/fix getting branch HEAD commit hash

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,10 +30,9 @@ jobs:
           (
             echo ALPINE_VERSION="$ALPINE_VERSION"
             echo PYTHON_VERSION="$PYTHON_VERSION"
-            echo TASK_VERSION="$TASK_VERSION"
+            echo TASK_VERSION="$TASK_VERSION" ${TASK_DEVEL_SHA:+TASK_DEVEL_SHA="$TASK_DEVEL_SHA"}
             echo VIM_VERSION="$VIM_VERSION"
             echo VIMWIKI_VERSION="$VIMWIKI_VERSION"
-            echo TASK_DEVEL_SHA="$TASK_DEVEL_SHA"
             cat Dockerfile
           ) | sha256sum | read -r tag _
           docker login "$DOCKER_REGISTRY" -u "$GITHUB_USER" -p "$GITHUB_TOKEN" || :

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,11 +26,7 @@ jobs:
         run: |
           set -ex -o pipefail
           shopt -s lastpipe
-          (
-            echo -n sha:
-            git ls-remote https://github.com/GothenburgBitFactory/taskwarrior.git | \
-            ( grep heads/$TASK_VERSION || : ) | awk '{print $1}'
-          ) | read -r TASK_DEVEL_SHA _ || :
+          git ls-remote https://github.com/GothenburgBitFactory/taskwarrior.git heads/"$TASK_VERSION" | read -r TASK_DEVEL_SHA _ || :
           (
             echo ALPINE_VERSION="$ALPINE_VERSION"
             echo PYTHON_VERSION="$PYTHON_VERSION"


### PR DESCRIPTION
`git ls-remote 'heads/'` doesn't return anything, while `grep 'heads/'`
returns all branches, so a taskwarrior push caused most docker images
(those that don't have any TASK_VERSION and fallback to the Dockerfile
default) to be rebuilt, not just the one that needs to be. This is fixed
by giving the desired branch to `git ls-remote` directly.

Plus a simplification (`read -r A _` doesn't need `awk '{print $1}'`)
and a little cleanup that reuses old docker images.