### PR TITLE
Show uuid for tasks with no id

### DIFF
--- a/taskwiki/sort.py
+++ b/taskwiki/sort.py
@@ -181,7 +181,7 @@ class TaskCollectionNode(object):
         return full_list
 
     def __repr__(self):
-        return u"Node for with ID: {0}".format(self.vwtask.task['id'])
+        return u"Node for with ID: {0}".format(self.vwtask.task['id'] or self.vwtask.task['uuid'])
 
     def __lt__(self, other):
         return self.comparator.lt(self, other)


### PR DESCRIPTION
When there is an error for instance about a task having multiple parents, taskwiki shows an error referencing the task ID. For deleted tasks with no id, the message is not helpful. This PR shows the uuid for tasks with no id.