### PR TITLE
Adds +VISIBLE metatag

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -405,7 +405,7 @@ Examples:
 -----------------------
 5.2.5 Meta virtual tags
 
-Currently there is one meta virtual tag: -VISIBLE. This tag can be used to
+Currently there is one meta virtual tag: VISIBLE. This tag can be used to
 filter out tasks that are displayed elsewhere in the same taskwiki file.
 
 Example:
@@ -413,6 +413,15 @@ Example:
 ~    == Work tasks not belonging to any subproject | project:Work -VISIBLE ==
 ~    == Work coding tasks | project:Work.Coding ==
 ~    == Work review tasks | project:Work.Review ==
+
+Reversely, it can be used to display under a viewport only tasks that are
+already displayed in the same taskwiki file.
+
+Example:
+
+~    == All work tasks by priority | +VISIBLE
+~    == Task for main work | project:Work.main ==
+~    == Tasks for weekend work | project:Work.weekend ==
 
 ----------------
 5.2.6 Inspection

--- a/taskwiki/viewport.py
+++ b/taskwiki/viewport.py
@@ -29,7 +29,7 @@ class ViewPort(object):
           * [ ] Make sure the hosting is working
     """
 
-    meta_tokens = ('-VISIBLE',)
+    meta_tokens = ('-VISIBLE', '+VISIBLE')
 
     def __init__(self, line_number, cache, tw,
                  name, filterstring, defaultstring, sort=None):
@@ -171,6 +171,8 @@ class ViewPort(object):
         for token in taskfilter_args:
             if token == '-VISIBLE':
                 meta['visible'] = False
+            elif token == '+VISIBLE':
+                meta['visible'] = True
 
         taskfilter_args = [x for x in taskfilter_args
                            if x not in self.meta_tokens]
@@ -282,7 +284,7 @@ class ViewPort(object):
                 task for task in self.tw.tasks.filter(*args)
             )
         # -VISIBLE virtual tag used
-        elif self.meta.get('visible') is False:
+        elif self.meta.get('visible') is not None:
             # Determine which tasks are outside the viewport
             all_vwtasks = set(self.cache.vwtask.values())
             vwtasks_outside_viewport = all_vwtasks - set(self.tasks)
@@ -291,12 +293,20 @@ class ViewPort(object):
                 if t is not None
             )
 
-            # Return only those that are not duplicated outside
-            # of the viewport
-            return set(
-                task for task in self.tw.tasks.filter(*args)
-                if task not in tasks_outside_viewport
-            )
+            if not self.meta['visible']:
+                # Return only those that are not duplicated outside
+                # of the viewport
+                return set(
+                    task for task in self.tw.tasks.filter(*args)
+                    if task not in tasks_outside_viewport
+                )
+            else:
+                # Return only those that are duplicated outside
+                # of the viewport
+                return set(
+                    task for task in self.tw.tasks.filter(*args)
+                    if task in tasks_outside_viewport
+                )
 
     def get_tasks_to_add_and_del(self):
         # Find the tasks that are new and tasks that are no longer


### PR DESCRIPTION
Adds a +VISIBLE metatag to display tasks already displayed in the file. This is useful to have different or aggregate sortings of tasks. For instance, you can have 2 projects that track your work under two different viewports. These 2 projects are equally important. On the top of the file, you just use a `<name> | +VISIBLE` viewport and you get all the tasks from both projects ordered by priority, so that you know which one you should work on first.