### PR TITLE
Some fixes for folding

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -54,7 +54,3 @@ setlocal conceallevel=3
 if !exists('g:taskwiki_disable_concealcursor')
   setlocal concealcursor=nc
 endif
-
-" Configure custom FoldText function
-setlocal foldmethod=syntax
-setlocal foldtext=taskwiki#FoldText()

--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -56,19 +56,6 @@ if !exists('g:taskwiki_disable_concealcursor')
 endif
 
 " Configure custom FoldText function
-" Altered version of the VimwikiFoldText
 setlocal foldmethod=syntax
+setlocal foldtext=taskwiki#FoldText()
 setlocal viewoptions-=options
-
-function! TaskwikiFoldText()
-  let line = getline(v:foldstart)
-  let main_text = substitute(line, '^\s*', repeat(' ',indent(v:foldstart)), '')
-  let short_text = substitute(main_text, '|[^=]* =', '=', '')
-  let short_text = substitute(short_text, '@[^=]* =', '=', '')
-  let short_text = substitute(short_text, ' @[A-Za-z0-9]\+', '', '')
-  let fold_len = v:foldend - v:foldstart + 1
-  let len_text = ' ['.fold_len.'] '
-  return short_text.len_text.repeat(' ', 500)
-endfunction
-
-setlocal foldtext=TaskwikiFoldText()

--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -58,4 +58,3 @@ endif
 " Configure custom FoldText function
 setlocal foldmethod=syntax
 setlocal foldtext=taskwiki#FoldText()
-setlocal viewoptions-=options

--- a/autoload/taskwiki.vim
+++ b/autoload/taskwiki.vim
@@ -1,6 +1,14 @@
 if exists('g:loaded_taskwiki_auto') | finish | endif
 let g:loaded_taskwiki_auto = 1
 
+function! taskwiki#FoldInit() abort
+  " Unless vimwiki is configured to use its folding, set our own
+  if &foldtext !~? 'VimwikiFold'
+    setlocal foldmethod=syntax
+    setlocal foldtext=taskwiki#FoldText()
+  endif
+endfunction
+
 " Altered version of the VimwikiFoldText, strips viewport params
 function! taskwiki#FoldText()
   let line = getline(v:foldstart)

--- a/autoload/taskwiki.vim
+++ b/autoload/taskwiki.vim
@@ -1,0 +1,14 @@
+if exists('g:loaded_taskwiki_auto') | finish | endif
+let g:loaded_taskwiki_auto = 1
+
+" Altered version of the VimwikiFoldText, strips viewport params
+function! taskwiki#FoldText()
+  let line = getline(v:foldstart)
+  let main_text = substitute(line, '^\s*', repeat(' ',indent(v:foldstart)), '')
+  let short_text = substitute(main_text, '|[^=]* =', '=', '')
+  let short_text = substitute(short_text, '@[^=]* =', '=', '')
+  let short_text = substitute(short_text, ' @[A-Za-z0-9]\+', '', '')
+  let fold_len = v:foldend - v:foldstart + 1
+  let len_text = ' ['.fold_len.'] '
+  return short_text.len_text.repeat(' ', 500)
+endfunction

--- a/autoload/taskwiki.vim
+++ b/autoload/taskwiki.vim
@@ -1,6 +1,18 @@
 if exists('g:loaded_taskwiki_auto') | finish | endif
 let g:loaded_taskwiki_auto = 1
 
+function! taskwiki#MkView() abort
+  let viewoptions = &viewoptions
+  set viewoptions-=options
+  mkview
+  let &viewoptions = viewoptions
+endfunction
+
+function! taskwiki#LoadView() abort
+  silent! loadview
+  silent! doautocmd SessionLoadPost
+endfunction
+
 function! taskwiki#FoldInit() abort
   " Unless vimwiki is configured to use its folding, set our own
   if &foldtext !~? 'VimwikiFold'

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -41,10 +41,8 @@ augroup taskwiki
     autocmd BufWrite <buffer> TaskWikiBufferSave
     " Save and load the view to preserve folding, if desired
     if !exists('g:taskwiki_dont_preserve_folds')
-      setlocal viewoptions-=options
-      autocmd BufWinLeave <buffer> mkview
-      autocmd BufWinEnter <buffer> silent! loadview
-      autocmd BufWinEnter <buffer> silent! doautocmd SessionLoadPost
+      autocmd BufWinLeave <buffer> call taskwiki#MkView()
+      autocmd BufWinEnter <buffer> call taskwiki#LoadView()
     endif
     " Reset cache when switching buffers
     execute "autocmd BufEnter <buffer> :" . g:taskwiki_py . "cache.load_current().reset()"

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -46,7 +46,10 @@ augroup taskwiki
       autocmd BufWinEnter <buffer> silent! loadview
       autocmd BufWinEnter <buffer> silent! doautocmd SessionLoadPost
     endif
+    " Reset cache when switching buffers
     execute "autocmd BufEnter <buffer> :" . g:taskwiki_py . "cache.load_current().reset()"
+    " Update window-local fold options
+    autocmd BufWinEnter <buffer> call taskwiki#FoldInit()
 
     " Refresh on load (if possible, after loadview to preserve folds)
     if has('patch-8.1.1113') || has('nvim-0.4.0')

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -41,6 +41,7 @@ augroup taskwiki
     autocmd BufWrite <buffer> TaskWikiBufferSave
     " Save and load the view to preserve folding, if desired
     if !exists('g:taskwiki_dont_preserve_folds')
+      setlocal viewoptions-=options
       autocmd BufWinLeave <buffer> mkview
       autocmd BufWinEnter <buffer> silent! loadview
       autocmd BufWinEnter <buffer> silent! doautocmd SessionLoadPost

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tasklib>=2.2.1
+six

--- a/tests/base.py
+++ b/tests/base.py
@@ -67,6 +67,7 @@ class IntegrationTest(object):
                 raise
 
     def configure_global_variables(self):
+        self.command('set foldlevel=99')
         self.command('let g:taskwiki_data_location="{0}"'.format(self.dir))
         self.command('let g:taskwiki_taskrc_location="{0}"'.format(self.taskrc_path))
         self.command('let g:vimwiki_list = [{"syntax": "%s", "ext": ".txt","path": "%s"}]' % (self.markup, self.dir))


### PR DESCRIPTION
Fixes for vimwiki and taskwiki fighting over foldmethod and foldtext.

In default vimwiki configuration (no folding), taskwiki takes over and
uses syntax foldmethod as it did originally before vimwiki started
overriding it.

If vimwiki is configured to use one of its (likely faster) folding
methods, taskwiki no longer tries to set its own.

There are still some issues, though: since (probably) ebd397d59c,
preserving of open/closed folds isn't reliable as vim can't reliably
track folds when the entire buffer is changed. I have some ideas here,
but no idea when I can get to it, if at all.