### PR TITLE
completion: Fix omni completion of non-ascii tasks

### DIFF
--- a/taskwiki/completion.py
+++ b/taskwiki/completion.py
@@ -125,8 +125,9 @@ class Completion():
 
     def omni_modstring_findstart(self, line):
         m = re.search(regexp.GENERIC_TASK, line)
-        if m and not m.group('uuid') and ' -- ' in line:
-            return line.rfind(' ') + 1
+        bline = line.encode("utf-8")  # omni findstart needs byte offset
+        if m and not m.group('uuid') and b' -- ' in bline:
+            return bline.rfind(b' ') + 1
         else:
             return -1
 

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -102,6 +102,14 @@ class TestCompletionIntegOmni(IntegrationTest):
         self.client.eval('0')  # wait for command completion
         self.command("w", regex="written$", lines=1)
 
+        self.client.feedkeys('otest task ☺ -- pro\\<C-X>\\<C-O>A\\<C-X>\\<C-O>\\<Esc>')
+        self.client.eval('0')  # wait for command completion
+        self.command("w", regex="written$", lines=1)
+
         task = self.tw.tasks.pending()[1]
         assert task['description'] == 'test task 2'
+        assert task['project'] == 'ABC'
+
+        task = self.tw.tasks.pending()[2]
+        assert task['description'] == 'test task ☺'
         assert task['project'] == 'ABC'


### PR DESCRIPTION
vim uses bytes as column offsets, so we need to work with encoded
strings instead.