### PR TITLE
Only adjust conceallevel if taskwiki_disable_concealcursor unset

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -50,7 +50,7 @@ syntax cluster TaskWikiTaskContains add=TaskWikiTaskPriority
 
 " Set concealed parts as really concealed in normal mode, and with cursor over
 " (unless disabled by user)
-setlocal conceallevel=3
 if !exists('g:taskwiki_disable_concealcursor')
+  setlocal conceallevel=3
   setlocal concealcursor=nc
 endif


### PR DESCRIPTION
`g:taskwiki_disable_concealcursor` is used to control whether or not
Taskwiki sets `concealcursor`. Move the setting of `conceallevel` to
also dpend upon `g:taskwiki_disable_concealcursor`, the reasoning
being that if the user does not want Taskwiki to set `concealcursor`,
they most likely don't want `conceallevel` changed either.

Fixes #325.