### PR TITLE
include info about pynvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Python library for Taskwarrior.
 
         sudo pip3 install --upgrade -r requirements.txt
 
+* **For neovim users:** Note that `pynvim` is a required python 3 provider in case you are using neovim
+
+        sudo pip3 install pynvim
+
 #### Python2 support
 
 Taskwiki is slowly deprecating Python 2 support. Future features are no longer


### PR DESCRIPTION
I was lost because TaskWiki would not work with my nvim. It turned out that my python3 provider was not available. Installing this dependency - pynvim, solved the issue. I hope I can save other nvm users time by providing this info.