### PR TITLE
add toggle to disable taskwiki's custom foldikng logic

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -732,6 +732,10 @@ constructs.
     If set to a non-empty value (such as "yes"), taskwiki will not
     preserve folding when entering or leaving a vimwiki buffer.
 
+*taskwiki_dont_fold*
+    If set to a non-empty value (such as "yes"), taskwiki will not
+    set up custom folding logic for vimwiki buffers.
+
 *taskwiki_disable_concealcursor*
     If set to any non-empty value (such as "yes"), taskwiki will not conceal
     characters on the cursor line in normal mode via `concealcursor=nc`.

--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -47,7 +47,9 @@ augroup taskwiki
     " Reset cache when switching buffers
     execute "autocmd BufEnter <buffer> :" . g:taskwiki_py . "cache.load_current().reset()"
     " Update window-local fold options
-    autocmd BufWinEnter <buffer> call taskwiki#FoldInit()
+    if !exists('g:taskwiki_dont_fold')
+      autocmd BufWinEnter <buffer> call taskwiki#FoldInit()
+    endif
 
     " Refresh on load (if possible, after loadview to preserve folds)
     if has('patch-8.1.1113') || has('nvim-0.4.0')


### PR DESCRIPTION
Closes #366
- add toggle to disable custom folding for vimwiki files
- add documentation for the new `g:taskwiki_dont_fold` global variable