### PR TITLE
Adds option to force update same task mentions in current file

### DIFF
--- a/doc/taskwiki.txt
+++ b/doc/taskwiki.txt
@@ -767,6 +767,15 @@ constructs.
         Example:
         let g:taskwiki_maplocalleader=",t"
 
+*taskwiki_scan_for_duplicates*
+    If set to a non-empty value (such as "yes"), taskwiki will force-scan the
+    current file for other mentions of the task being processed and update
+    them too. This is useful if you have multiple overlapping viewports. If
+    you edit a task that appears in several of these viewports (e.g. mark it
+    as done) and save the file, the non-updated mentions of the task may undo
+    your edits. This option is disabled by default as it will add some
+    overhead to simple operations that you perform on selected tasks.
+
 =============================================================================
 9. TROUBLESHOOTING					   *taskwiki-trouble*
 

--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -313,3 +313,6 @@ class TaskCache(object):
 
     def get_relevant_completion(self):
         return self.completion[self.get_relevant_tw()]
+
+    def get_task_replications(self, uuid):
+        return [vwtask for vwtask in self.vwtask.values() if vwtask and vwtask.uuid == uuid]

--- a/taskwiki/main.py
+++ b/taskwiki/main.py
@@ -79,6 +79,10 @@ class SelectedTasks(object):
         self.tw = cache().get_relevant_tw()
 
         # Load the current tasks
+        if util.get_var('taskwiki_scan_for_duplicates'):
+            for i in range(len(cache().buffer)):
+                cache().vwtask[i]  # loads the line into the cache
+
         range_tasks = [cache().vwtask[i] for i in util.selected_line_numbers()]
         self.tasks = [t for t in range_tasks if t is not None]
 
@@ -113,6 +117,8 @@ class SelectedTasks(object):
             vimwikitask.update_from_task()
             vimwikitask.update_in_buffer()
             print(u"Task \"{0}\" completed.".format(vimwikitask['description']))
+
+        self._update_replications()
 
         cache().buffer.push()
         self.save_action('done')
@@ -276,6 +282,14 @@ class SelectedTasks(object):
     def sort(self, sortstring):
         sort.TaskSorter(cache(), self.tasks, sortstring).execute()
         cache().buffer.push()
+
+    def _update_replications(self):
+        """Update all same tasks occurrences in current buffer from taskwarrior."""
+
+        for vimwikitask in self.tasks:
+            for replica in cache().get_task_replications(vimwikitask.uuid):
+                replica.update_from_task()
+                replica.update_in_buffer()
 
 
 class Mappings(object):


### PR DESCRIPTION
This tries to fix the case when multiple viewports list the same task. Updating the task in one of them and saving can have the unwanted result that the changes get reverted as taskwiki uses non-updated mentions of the task as authoritative.

For example:

```
# Viewport 1 | project:parent
* [ ] My task

# Viewport 2 | project:parent.child
* [X] My task

# Viewport 3 | +label
* [ ] My task
```

In this scenario, where the second occurrence of the task has been marked as complete (with the TaskWikiDone command), if the user saves the file, the task will be marked as pending. Common change logs for such tasks look like:

```
2022-01-31 09:46:27 End set to '2022-01-31 09:46:27'.
                    Status changed from 'pending' to 'completed'.
2022-01-31 09:47:24 End deleted.
                    Status changed from 'completed' to 'pending'.
2022-02-01 10:34:55 End set to '2022-02-01 10:34:55'.
                    Status changed from 'pending' to 'completed'.
2022-02-01 11:16:33 End deleted.
                    Status changed from 'completed' to 'pending'.
2022-02-01 11:17:43 End set to '2022-02-01 11:17:43'.
                    Status changed from 'pending' to 'completed'.
2022-02-01 15:30:37 End deleted.
                    Status changed from 'completed' to 'pending'.
2022-02-02 10:47:29 End set to '2022-02-02 10:47:29'.
                    Status changed from 'pending' to 'completed'.
2022-02-02 10:47:33 End deleted.
                    Status changed from 'completed' to 'pending'.
2022-02-02 10:49:42 End set to '2022-02-02 10:49:42'.
                    Status changed from 'pending' to 'completed'.
2022-02-02 10:49:53 End changed from '2022-02-02 10:49:42' to '2022-02-02 10:49:52'.
```

bouncing between pending and completed. This happens for other task attributes as well (e.g. due time).

PS: I would really like to write tests for any pending PR I have and have them merged, but I can't get the test suite to work.