### PR TITLE
vwtask: honour tabstop setting

### DIFF
--- a/taskwiki/cache.py
+++ b/taskwiki/cache.py
@@ -17,6 +17,9 @@ class BufferProxy(object):
         self.data = []
         self.buffer_number = number
 
+    def options(self):
+        return util.get_buffer(self.buffer_number).options
+
     def obtain(self):
         self.data = util.get_buffer(self.buffer_number)[:]
 

--- a/taskwiki/sort.py
+++ b/taskwiki/sort.py
@@ -166,8 +166,9 @@ class TaskCollectionNode(object):
         self.vwtask['indent'] = ' ' * indent
         self.vwtask.update_in_buffer()
 
+        tabstop = self.vwtask.cache.buffer.options()['tabstop']
         for child in self.children:
-            child.build_indentation(indent + 4)
+            child.build_indentation(indent + tabstop)
 
     def sort(self):
         self.children.sort()

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -340,17 +340,19 @@ class VimwikiTask(object):
             '  #' + self.uuid.vim_representation(self.cache) if self.uuid else '',
         ])
 
+    def _normalise_indent(self, string):
+        tabstop = self.cache.buffer.options()['tabstop']
+        return string.replace('\t', ' ' * tabstop)
+
     def find_parent_task(self):
         # If this task is not indented, we have nothing to do here
         if not self['indent']:
             return None
 
         for i in reversed(range(0, self['line_number'])):
-            # Tab is equal to four spaces
-            # TODO: Source this from tabstop setting, but this would be only
-            # useful for mixed tab/space indentations
-            indentation = len(self.cache.buffer[i].replace('\t', '    ')) - len(self.cache.buffer[i].lstrip())
-            indent = self['indent'].replace('\t', '    ')
+            line = self.cache.buffer[i]
+            indentation = len(self._normalise_indent(line)) - len(line.lstrip())
+            indent = self._normalise_indent(self['indent'])
 
             if indentation < len(indent):
                 # The from_line constructor returns None if line doesn't match a task


### PR DESCRIPTION
This makes Taskwiki honour the value of `tabstop` set for the current
buffer instead of always rewriting the indentation of dependent tasks
with four spaces regardless of that setting.

Relates-to: 146d089 (https://github.com/tools-life/taskwiki/issues/352)
GitHub: closes https://github.com/tools-life/taskwiki/issues/405