### PR TITLE
Markdown Headings should be surrounded by blank lines

### DIFF
--- a/ftplugin/vimwiki/taskwiki.vim
+++ b/ftplugin/vimwiki/taskwiki.vim
@@ -96,16 +96,16 @@ execute "command! -buffer -range TaskWikiChooseTag :<line1>,<line2>"         . g
 " Meta commands
 execute "command! -buffer TaskWikiInspect :" . g:taskwiki_py . "Meta().inspect_viewport()"
 
-" Disable <CR> as VimwikiFollowLink
-if !hasmapto('<Plug>VimwikiFollowLink')
-  nmap <Plug>NoVimwikiFollowLink <Plug>VimwikiFollowLink
-endif
-
-execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
-
-" Leader-related mappings. Mostly <Leader>t + <first letter of the action>
 if !exists('g:taskwiki_suppress_mappings')
-        if exists('g:taskwiki_maplocalleader')
+  " Disable <CR> as VimwikiFollowLink
+  if !hasmapto('<Plug>VimwikiFollowLink')
+    nmap <Plug>NoVimwikiFollowLink <Plug>VimwikiFollowLink
+  endif
+
+  execute "nnoremap <silent><buffer> <CR> :" . g:taskwiki_py . "Mappings.task_info_or_vimwiki_follow_link()<CR>"
+
+  " Leader-related mappings. Mostly <Leader>t + <first letter of the action>
+  if exists('g:taskwiki_maplocalleader')
                 let maplocalleader = g:taskwiki_maplocalleader
         else
                 if exists('g:mapleader')

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -85,6 +85,7 @@ VIEWPORT = {
         r'(limit:(?P<count>[0-9]+))?'    # Optional count indicator
         r'\s*'                           # Any whitespace
         r'$'                             # End of line
+        r'\n'                            # New Line
     )
 }
 
@@ -135,6 +136,7 @@ PRESET = {
         r')?'
         r'\s*'                       # Any whitespace
         r'$'                         # End of line
+        r'\n'                        # New Line
     )
 }
 

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -110,7 +110,7 @@ class VimwikiTask(object):
                 len(match.group('priority') or [])) # This is either 0,1,2 or 3
 
             # Also make sure changes in the progress field are reflected
-            if self['completed_mark'] == 'X':
+            if self['completed_mark'].lower() == 'x':
                 self.task['status'] = 'completed'
                 self.task['start'] = None
                 self.task['end'] = self.task['end'] or datetime.now()
@@ -280,8 +280,8 @@ class VimwikiTask(object):
         mark = self['completed_mark']
 
         if self.task.completed:
-            mark = 'X'
-        elif mark == 'X':
+            mark = 'x'
+        elif mark == 'x':
             mark = ' '
 
         if self.task.active:


### PR DESCRIPTION
Per the spec used by [Markdownlint](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md022---headings-should-be-surrounded-by-blank-lines), and generally other markdown rendering applications. Markdown headings generally have an extra line of space between the heading and the content. This commit adds that spacing to a viewport when it is rendered. 