### PR TITLE
Custom UUID char

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -34,8 +34,8 @@ syntax cluster TaskWikiTaskContains
                 \ @Spell
 
 " Conceal the UUID
-execute 'syn match TaskWikiTaskUuid containedin=TaskWikiTask /\v#([A-Z]:)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/'.s:conceal
-execute 'syn match TaskWikiTaskUuid containedin=TaskWikiTask /\v#([A-Z]:)?[0-9a-fA-F]{8}$/'.s:conceal
+execute 'syn match TaskWikiTaskUuid containedin=TaskWikiTask /\V'.s:uuid_char.'\v([A-Z]:)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/'.s:conceal
+execute 'syn match TaskWikiTaskUuid containedin=TaskWikiTask /\V'.s:uuid_char.'\v([A-Z]:)?[0-9a-fA-F]{8}$/'.s:conceal
 highlight link TaskWikiTaskUuid Comment
 
 " Conceal header definitions
@@ -45,11 +45,11 @@ endfor
 
 " Define active and deleted task regions
 " Will be colored dynamically by Meta().source_tw_colors()
-syntax match TaskWikiTaskActive containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[S\]\s[^#]*/
-syntax match TaskWikiTaskCompleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[X\]\s[^#]*/
-syntax match TaskWikiTaskDeleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s*\[D\]\s[^#]*/
-syntax match TaskWikiTaskRecurring containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[R\]\s[^#]*/
-syntax match TaskWikiTaskWaiting containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[W\]\s[^#]*/
+execute 'syntax match TaskWikiTaskActive containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[S\]\s[^'.s:uuid_char.']*/'
+execute 'syntax match TaskWikiTaskCompleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[X\]\s[^'.s:uuid_char.']*/'
+execute 'syntax match TaskWikiTaskDeleted containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s*\[D\]\s[^'.s:uuid_char.']*/'
+execute 'syntax match TaskWikiTaskRecurring containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[R\]\s[^'.s:uuid_char.']*/'
+execute 'syntax match TaskWikiTaskWaiting containedin=TaskWikiTask contained contains=@TaskWikiTaskContains /\s*\*\s\[W\]\s[^'.s:uuid_char.']*/'
 syntax match TaskWikiTaskPriority contained /\( \)\@<=\(!\|!!\|!!!\)\( \)\@=/
 syntax cluster TaskWikiTaskContains add=TaskWikiTaskPriority
 

--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -6,6 +6,11 @@ endif
 " Detect if conceal feature is available
 let s:conceal = exists("+conceallevel") ? ' conceal': ''
 
+let s:uuid_char = '#'
+if exists("g:taskwiki_uuid_char")
+    let s:uuid_char = g:taskwiki_uuid_char
+endif
+
 syntax match TaskWikiTask /\s*\* \[.\]\s.*$/ contains=@TaskWikiTaskContains
 syntax cluster TaskWikiTaskContains
        \ contains=VimwikiListTodo,

--- a/taskwiki/regexp.py
+++ b/taskwiki/regexp.py
@@ -1,5 +1,7 @@
 import re
 
+from taskwiki.util import uuid_char
+
 # Unnamed building blocks
 UUID_UNNAMED = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 UUID_UNNAMED_SHORT = r'[0-9a-fA-F]{8}'
@@ -30,7 +32,7 @@ GENERIC_TASK = re.compile(''.join([
     '(', PRIORITY, FINAL_SEGMENT_SEPARATOR_UNNAMED, ')?',
     '(', DUE, FINAL_SEGMENT_SEPARATOR_UNNAMED, ')?',
     '(',
-        '#',
+        re.escape(uuid_char),
         '(', SOURCE_INDICATOR, ')?',
         '(', UUID, ')?',
     ')?',  # UUID is not there for new tasks

--- a/taskwiki/util.py
+++ b/taskwiki/util.py
@@ -13,6 +13,8 @@ import tasklib
 from taskwiki.errors import TaskWikiException
 from taskwiki import regexp
 
+uuid_char = vim.eval("g:taskwiki_uuid_char") if vim.eval("exists('g:taskwiki_uuid_char')") == '1' else '#'
+
 # Detect if command AnsiEsc is available
 ANSI_ESC_AVAILABLE = vim.eval('exists(":AnsiEsc")') == '2'
 NEOVIM = (vim.eval('has("nvim")') == "1")

--- a/taskwiki/vwtask.py
+++ b/taskwiki/vwtask.py
@@ -8,6 +8,7 @@ from tasklib import Task
 
 from taskwiki import regexp
 from taskwiki import util
+from taskwiki.util import uuid_char
 from taskwiki.short import ShortUUID
 
 
@@ -337,7 +338,7 @@ class VimwikiTask(object):
                 if self['description'] else 'TEXT MISSING?',
             ' ' + '!' * self.priority_from_tw_format if self['priority'] else '',
             due_str,
-            '  #' + self.uuid.vim_representation(self.cache) if self.uuid else '',
+            '  ' + uuid_char + self.uuid.vim_representation(self.cache) if self.uuid else '',
         ])
 
     def find_parent_task(self):

--- a/tests/test_choose.py
+++ b/tests/test_choose.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
+from taskwiki.util import uuid_char
 from tests.base import IntegrationTest
 
 
 class TestChooseProject(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -36,13 +37,13 @@ class TestChooseProject(IntegrationTest):
 class TestChooseProjectUnset(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -67,13 +68,13 @@ class TestChooseProjectUnset(IntegrationTest):
 class TestChooseProjectCanceled(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -98,13 +99,13 @@ class TestChooseProjectCanceled(IntegrationTest):
 class TestChooseTag(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -129,13 +130,13 @@ class TestChooseTag(IntegrationTest):
 class TestChooseTagCancelled(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -160,13 +161,13 @@ class TestChooseTagCancelled(IntegrationTest):
 class TestChooseTagNoSelected(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -191,13 +192,13 @@ class TestChooseTagNoSelected(IntegrationTest):
 class TestChooseProjectUnicode(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -222,13 +223,13 @@ class TestChooseProjectUnicode(IntegrationTest):
 class TestChooseTagUnicode(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from taskwiki.completion import Completion
+from taskwiki.util import uuid_char
 from tests.base import IntegrationTest
 
 
@@ -57,8 +58,8 @@ class TestCompletionUnit():
         c = Completion(FakeTW())
         assert c.omni_modstring_findstart("* [ ] x") == -1
         assert c.omni_modstring_findstart("* [ ] x --") == -1
-        assert c.omni_modstring_findstart("* [ ] x #12345678 --") == -1
-        assert c.omni_modstring_findstart("* [ ] x -- #12345678") == -1
+        assert c.omni_modstring_findstart("* [ ] x "+uuid_char+"12345678 --") == -1
+        assert c.omni_modstring_findstart("* [ ] x -- "+uuid_char+"12345678") == -1
         assert c.omni_modstring_findstart("* [ ] x -- ") == 11
         assert c.omni_modstring_findstart("* [ ] x -- x") == 11
         assert c.omni_modstring_findstart("* [ ] x -- xy") == 11
@@ -67,8 +68,8 @@ class TestCompletionUnit():
 
 class TestCompletionIntegMod(IntegrationTest):
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -89,7 +90,7 @@ class TestCompletionIntegMod(IntegrationTest):
 
 class TestCompletionIntegOmni(IntegrationTest):
     viminput = """
-    * [ ] test task 1  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
     """
 
     tasks = [

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
+from taskwiki.util import uuid_char
 from tests.base import IntegrationTest
 
 
 class TestDefaultMapping(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -34,13 +35,13 @@ class TestDefaultMapping(IntegrationTest):
 class TestSuppressedMapping(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -67,13 +68,13 @@ class TestSuppressedMapping(IntegrationTest):
 class TestCustomMapping(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -100,13 +101,13 @@ class TestCustomMapping(IntegrationTest):
 class TestColonRemap(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -134,13 +135,13 @@ class TestColonRemap(IntegrationTest):
 class TestColonRemapWithCustomMap(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -1,3 +1,4 @@
+from taskwiki.util import uuid_char
 from tests.base import MultiSyntaxIntegrationTest
 
 
@@ -10,7 +11,7 @@ class TestPresetDefaults(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER3(Work tasks || +work)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -36,7 +37,7 @@ class TestPresetHierarchy(MultiSyntaxIntegrationTest):
     HEADER2(Work tasks || +work)
     HEADER3(Hard work tasks || +hard)
     HEADER3(Easy work tasks || +easy)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -58,7 +59,7 @@ class TestPresetSeparateDefaults(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER1(Work tasks || +work or +play || +work)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -82,7 +83,7 @@ class TestPresetNestedDefaults(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks || +work)
     HEADER3(Hard work || +hard)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -105,7 +106,7 @@ class TestPresetViewport(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks || +work)
     HEADER3(Hard work | +hard)
-    * [ ] tag hard work task  #{uuid}
+    * [ ] tag hard work task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -130,7 +131,7 @@ class TestPresetIgnoreViewport(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks | +work)
     HEADER3(Hard work || +hard)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -154,7 +155,7 @@ class TestPresetViewportDefaultsYesNo(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks || project:Work or project:Play || project:Work)
     HEADER3(Hard work | +hard)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -179,7 +180,7 @@ class TestPresetViewportDefaultsNoYes(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks || project:Work)
     HEADER3(Hard work | +hard or +easy | +hard)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -204,7 +205,7 @@ class TestPresetViewportDefaultsYesYes(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks || project:Work or project:Play || project:Work)
     HEADER3(Hard work | +hard or +easy | +hard)
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -229,7 +230,7 @@ class TestPresetDefaultPreservesTags(MultiSyntaxIntegrationTest):
     vimoutput = """
     HEADER2(Work tasks || +work)
     HEADER3(Work tasks | +hard)
-    * [ ] hard task  #{uuid}
+    * [ ] hard task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):

--- a/tests/test_selected.py
+++ b/tests/test_selected.py
@@ -2,14 +2,15 @@ import re
 
 from datetime import datetime
 from tasklib import local_zone
+from taskwiki.util import uuid_char
 from tests.base import IntegrationTest
 
 
 class TestAnnotateAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -32,8 +33,8 @@ class TestAnnotateAction(IntegrationTest):
 class TestAnnotateActionManually(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -55,8 +56,8 @@ class TestAnnotateActionManually(IntegrationTest):
 class TestAnnotateActionManuallyAbort(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -82,8 +83,8 @@ class TestAnnotateActionManuallyAbort(IntegrationTest):
 class TestAnnotateActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -107,8 +108,8 @@ class TestAnnotateActionMoved(IntegrationTest):
 class TestAnnotateActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -136,8 +137,8 @@ class TestAnnotateActionRange(IntegrationTest):
 class TestAnnotateActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -166,12 +167,12 @@ class TestAnnotateActionRedo(IntegrationTest):
 class TestDeleteAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -195,12 +196,12 @@ class TestDeleteAction(IntegrationTest):
 class TestDeleteActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -225,8 +226,8 @@ class TestDeleteActionMoved(IntegrationTest):
 class TestDeleteActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
@@ -253,8 +254,8 @@ class TestDeleteActionRange(IntegrationTest):
 class TestDeleteActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
@@ -290,8 +291,8 @@ class TestDeleteActionRedo(IntegrationTest):
 class TestInfoAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -317,8 +318,8 @@ class TestInfoAction(IntegrationTest):
 class TestInfoActionTriggeredByEnter(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -346,8 +347,8 @@ class TestInfoActionTriggeredByEnter(IntegrationTest):
 class TestInfoActionNotTriggeredByEnterOnLink(IntegrationTest):
 
     viminput = """
-    * [ ] [[link task]] 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] [[link task]] 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -371,8 +372,8 @@ class TestInfoActionNotTriggeredByEnterOnLink(IntegrationTest):
 class TestInfoActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -399,8 +400,8 @@ class TestInfoActionMoved(IntegrationTest):
 class TestInfoActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -428,8 +429,8 @@ class TestInfoActionRange(IntegrationTest):
 class TestLinkAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -454,8 +455,8 @@ class TestLinkAction(IntegrationTest):
 class TestLinkActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -481,8 +482,8 @@ class TestLinkActionMoved(IntegrationTest):
 class TestLinkActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -512,8 +513,8 @@ class TestLinkActionRange(IntegrationTest):
 class TestLinkActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -555,13 +556,13 @@ class TestLinkActionRedo(IntegrationTest):
 class TestStartAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [S] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -592,13 +593,13 @@ class TestStartAction(IntegrationTest):
 class TestToggleAction(IntegrationTest):
 
     viminput = """
-    * [S] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -635,13 +636,13 @@ class TestToggleAction(IntegrationTest):
 class TestStartActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -673,13 +674,13 @@ class TestStartActionMoved(IntegrationTest):
 class TestStartActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [S] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -711,13 +712,13 @@ class TestStartActionRange(IntegrationTest):
 class TestStartActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [S] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -759,13 +760,13 @@ class TestStartActionRedo(IntegrationTest):
 class TestStopAction(IntegrationTest):
 
     viminput = """
-    * [S] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -796,13 +797,13 @@ class TestStopAction(IntegrationTest):
 class TestStopActionMoved(IntegrationTest):
 
     viminput = """
-    * [S] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [S] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -834,13 +835,13 @@ class TestStopActionMoved(IntegrationTest):
 class TestStopActionRange(IntegrationTest):
 
     viminput = """
-    * [S] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -867,13 +868,13 @@ class TestStopActionRange(IntegrationTest):
 class TestStopActionRedo(IntegrationTest):
 
     viminput = """
-    * [S] test task 1  #{uuid}
-    * [S] test task 2  #{uuid}
+    * [S] test task 1  """+uuid_char+"""{uuid}
+    * [S] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -911,13 +912,13 @@ class TestStopActionRedo(IntegrationTest):
 class TestModAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -941,13 +942,13 @@ class TestModAction(IntegrationTest):
 class TestModActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -980,13 +981,13 @@ class TestModActionRedo(IntegrationTest):
 class TestModInteractiveAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1009,13 +1010,13 @@ class TestModInteractiveAction(IntegrationTest):
 class TestModInteractiveActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1046,8 +1047,8 @@ class TestModInteractiveActionRedo(IntegrationTest):
 class TestModVisibleAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1077,13 +1078,13 @@ class TestModVisibleAction(IntegrationTest):
 class TestModActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1108,13 +1109,13 @@ class TestModActionMoved(IntegrationTest):
 class TestModActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1141,13 +1142,13 @@ class TestModActionRange(IntegrationTest):
 class TestDoneAction(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1177,15 +1178,15 @@ class TestDoneAction(IntegrationTest):
 class TestDoneNoSelected(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
 
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
 
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1207,13 +1208,13 @@ class TestDoneNoSelected(IntegrationTest):
 class TestDoneActionMoved(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1245,13 +1246,13 @@ class TestDoneActionMoved(IntegrationTest):
 class TestDoneActionRange(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1283,13 +1284,13 @@ class TestDoneActionRange(IntegrationTest):
 class TestDoneActionRedo(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] test task 1  #{uuid}
-    * [X] test task 2  #{uuid}
+    * [X] test task 1  """+uuid_char+"""{uuid}
+    * [X] test task 2  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1330,13 +1331,13 @@ class TestDoneActionRedo(IntegrationTest):
 class TestSortManually(IntegrationTest):
 
     viminput = """
-    * [ ] test task 1  #{uuid}
-    * [ ] test task 2  #{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task 2  #{uuid}
-    * [ ] test task 1  #{uuid}
+    * [ ] test task 2  """+uuid_char+"""{uuid}
+    * [ ] test task 1  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -1352,11 +1353,11 @@ class TestSortManually(IntegrationTest):
 class TestSelectAfterBufferSwitch(IntegrationTest):
 
     viminput = """
-    * [ ] test task  #{uuid}
+    * [ ] test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] test task  #{uuid}
+    * [ ] test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [

--- a/tests/test_viewport.py
+++ b/tests/test_viewport.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from datetime import datetime
+from taskwiki.util import uuid_char
 from tests.base import MultiSyntaxIntegrationTest
 
 
@@ -12,7 +13,7 @@ class TestViewportsTaskGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -31,7 +32,7 @@ class TestViewportsTaskGenerationEmptyFilter(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks |)
-    * [ ] some task  #{uuid}
+    * [ ] some task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -46,7 +47,7 @@ class TestViewportsTaskRemoval(MultiSyntaxIntegrationTest):
 
     viminput = """
     HEADER2(Work tasks | -work)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
@@ -69,7 +70,7 @@ class TestViewportsContextTaskGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | @work)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -91,8 +92,8 @@ class TestViewportsContextComplexFilterTaskGeneration(MultiSyntaxIntegrationTest
 
     vimoutput = """
     HEADER2(Work tasks | @work or project:Home)
-    * [ ] home project task  #{uuid}
-    * [ ] tag work task  #{uuid}
+    * [ ] home project task  """+uuid_char+"""{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -115,8 +116,8 @@ class TestViewportsTwoContextTaskGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | @work or @home)
-    * [ ] home project task  #{uuid}
-    * [ ] tag work task  #{uuid}
+    * [ ] home project task  """+uuid_char+"""{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -156,7 +157,7 @@ class TestViewportDefaultsAssigment(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -225,10 +226,10 @@ class TestViewportDefaultsTerminatedByHeader(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
 
     HEADER2(Unrelated work tasks)
-    * [ ] not tagged work task  #{uuid}
+    * [ ] not tagged work task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -250,7 +251,7 @@ class TestViewportInspection(MultiSyntaxIntegrationTest):
 
     viminput = """
     HEADER2(Work tasks | +work)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
@@ -283,10 +284,10 @@ class TestViewportInspectionWithVisibleTag(MultiSyntaxIntegrationTest):
 
     viminput = """
     HEADER2(Work tasks | +work -VISIBLE)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
 
     HEADER2(Home tasks | +home)
-    * [ ] tag work task  #{uuid}
+    * [ ] tag work task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
@@ -323,7 +324,7 @@ class TestViewportsUnicodeTaskGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = u"""
     HEADER2(Work tasks | +work)
-    * [ ] tag work täsk  #{uuid}
+    * [ ] tag work täsk  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -342,7 +343,7 @@ class TestUnicodeViewportsUnicodeTaskGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = u"""
     HEADER2(Réunion 2017 | project:Réunion2017)
-    * [ ] Réunion task 1  #{uuid}
+    * [ ] Réunion task 1  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -363,7 +364,7 @@ class TestUnicodeViewportsUnicodeDefaultsAssignment(MultiSyntaxIntegrationTest):
 
     vimoutput = u"""
     HEADER2(Réunion 2017 | project:Réunion2017)
-    * [ ] Réunion task 1  #{uuid}
+    * [ ] Réunion task 1  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -384,15 +385,15 @@ class TestViewportsSortedGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] main task 1 (2015-08-07)  #{uuid}
-        * [ ] sub task 1a (2015-08-01)  #{uuid}
-            * [ ] sub task 1aa  #{uuid}
-        * [ ] sub task 1b  #{uuid}
-    * [ ] main task 2 (2015-08-08)  #{uuid}
-    * [ ] main task 3 (2015-08-09)  #{uuid}
-        * [ ] sub task 3a (2015-08-03)  #{uuid}
-        * [ ] sub task 3b  #{uuid}
-    * [ ] main task 4  #{uuid}
+    * [ ] main task 1 (2015-08-07)  """+uuid_char+"""{uuid}
+        * [ ] sub task 1a (2015-08-01)  """+uuid_char+"""{uuid}
+            * [ ] sub task 1aa  """+uuid_char+"""{uuid}
+        * [ ] sub task 1b  """+uuid_char+"""{uuid}
+    * [ ] main task 2 (2015-08-08)  """+uuid_char+"""{uuid}
+    * [ ] main task 3 (2015-08-09)  """+uuid_char+"""{uuid}
+        * [ ] sub task 3a (2015-08-03)  """+uuid_char+"""{uuid}
+        * [ ] sub task 3b  """+uuid_char+"""{uuid}
+    * [ ] main task 4  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -425,15 +426,15 @@ class TestViewportsSortedGenerationReverse(TestViewportsSortedGeneration):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] main task 3 (2015-08-09)  #{uuid}
-        * [ ] sub task 3a (2015-08-03)  #{uuid}
-        * [ ] sub task 3b  #{uuid}
-    * [ ] main task 2 (2015-08-08)  #{uuid}
-    * [ ] main task 1 (2015-08-07)  #{uuid}
-        * [ ] sub task 1a (2015-08-01)  #{uuid}
-            * [ ] sub task 1aa  #{uuid}
-        * [ ] sub task 1b  #{uuid}
-    * [ ] main task 4  #{uuid}
+    * [ ] main task 3 (2015-08-09)  """+uuid_char+"""{uuid}
+        * [ ] sub task 3a (2015-08-03)  """+uuid_char+"""{uuid}
+        * [ ] sub task 3b  """+uuid_char+"""{uuid}
+    * [ ] main task 2 (2015-08-08)  """+uuid_char+"""{uuid}
+    * [ ] main task 1 (2015-08-07)  """+uuid_char+"""{uuid}
+        * [ ] sub task 1a (2015-08-01)  """+uuid_char+"""{uuid}
+            * [ ] sub task 1aa  """+uuid_char+"""{uuid}
+        * [ ] sub task 1b  """+uuid_char+"""{uuid}
+    * [ ] main task 4  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -452,12 +453,12 @@ class TestViewportsMultilevelSortedGeneration(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | project:Work or project:Home)
-    * [ ] home task 1 (2015-08-01)  #{uuid}
-    * [ ] home task 2 (2015-08-02)  #{uuid}
-    * [ ] home task 3 (2015-08-03)  #{uuid}
-    * [ ] work task 1 (2015-08-01)  #{uuid}
-    * [ ] work task 2 (2015-08-02)  #{uuid}
-    * [ ] work task 3 (2015-08-03)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] home task 2 (2015-08-02)  """+uuid_char+"""{uuid}
+    * [ ] home task 3 (2015-08-03)  """+uuid_char+"""{uuid}
+    * [ ] work task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] work task 2 (2015-08-02)  """+uuid_char+"""{uuid}
+    * [ ] work task 3 (2015-08-03)  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -485,10 +486,10 @@ class TestViewportsSpecificSorting(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | project:Work or project:Home $T)
-    * [ ] home task 1 (2015-08-01)  #{uuid}
-    * [ ] home task 2 (2015-08-02)  #{uuid}
-    * [ ] work task 1 (2015-08-01)  #{uuid}
-    * [ ] work task 2 (2015-08-02)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] home task 2 (2015-08-02)  """+uuid_char+"""{uuid}
+    * [ ] work task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] work task 2 (2015-08-02)  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -516,16 +517,16 @@ class TestViewportsSpecificSortingCombined(TestViewportsSpecificSorting):
 
     vimoutput = """
     HEADER2(Work tasks | project:Work or project:Home $T)
-    * [ ] home task 1 (2015-08-01)  #{uuid}
-    * [ ] home task 2 (2015-08-02)  #{uuid}
-    * [ ] work task 1 (2015-08-01)  #{uuid}
-    * [ ] work task 2 (2015-08-02)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] home task 2 (2015-08-02)  """+uuid_char+"""{uuid}
+    * [ ] work task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] work task 2 (2015-08-02)  """+uuid_char+"""{uuid}
 
     HEADER2(Work tasks | project:Work or project:Home)
-    * [ ] home task 1 (2015-08-01)  #{uuid}
-    * [ ] work task 1 (2015-08-01)  #{uuid}
-    * [ ] home task 2 (2015-08-02)  #{uuid}
-    * [ ] work task 2 (2015-08-02)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] work task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] home task 2 (2015-08-02)  """+uuid_char+"""{uuid}
+    * [ ] work task 2 (2015-08-02)  """+uuid_char+"""{uuid}
     """
 
 
@@ -553,8 +554,8 @@ class TestViewportsCount(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | project:Work or project:Home limit:2)
-    * [ ] home task 1 (2015-08-01)  #{uuid}
-    * [ ] work task 1 (2015-08-01)  #{uuid}
+    * [ ] home task 1 (2015-08-01)  """+uuid_char+"""{uuid}
+    * [ ] work task 1 (2015-08-01)  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -579,10 +580,10 @@ class TestViewportsVisibleMetaTag(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Home tasks | project:Home -VISIBLE)
-    * [ ] home task  #{uuid}
+    * [ ] home task  """+uuid_char+"""{uuid}
 
     HEADER2(Chores | project:Home.Chores)
-    * [ ] chore task  #{uuid}
+    * [ ] chore task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -607,9 +608,9 @@ class TestViewportsPreserveHierarchyUponCompletion(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] main task  #{uuid}
-        * [X] sub task a  #{uuid}
-        * [ ] sub task b  #{uuid}
+    * [ ] main task  """+uuid_char+"""{uuid}
+        * [X] sub task a  """+uuid_char+"""{uuid}
+        * [ ] sub task b  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -628,7 +629,7 @@ class TestViewportDefaultPreservesTags(MultiSyntaxIntegrationTest):
 
     vimoutput = """
     HEADER2(Work tasks | +work)
-    * [ ] hard task  #{uuid}
+    * [ ] hard task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -645,7 +646,7 @@ class TestViewportBufferModified(MultiSyntaxIntegrationTest):
 
     viminput = """
     HEADER2(Work tasks |)
-    * [ ] a task  #{uuid}
+    * [ ] a task  """+uuid_char+"""{uuid}
     """
 
     tasks = [

--- a/tests/test_vwtask.py
+++ b/tests/test_vwtask.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 from tasklib import local_zone
+from taskwiki.util import uuid_char
 from tests.base import IntegrationTest, MultipleSourceTest
 
 
@@ -12,7 +13,7 @@ class TestSimpleTaskCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -29,11 +30,11 @@ class TestSimpleTaskCreation(IntegrationTest):
 class TestInvalidUUIDTask(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task  #abc123ef
+    * [ ] This is a test task  """+uuid_char+"""abc123ef
     """
 
     vimoutput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -50,11 +51,11 @@ class TestInvalidUUIDTask(IntegrationTest):
 class TestSimpleTaskModification(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is a modified task  #{uuid}
+    * [ ] This is a modified task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -80,11 +81,11 @@ class TestSimpleTaskModification(IntegrationTest):
 class TestBufferTaskCompletion(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [X] This is a test task  #{uuid}
+    * [X] This is a test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -112,11 +113,11 @@ class TestBufferTaskCompletion(IntegrationTest):
 class TestBufferTaskUncompletion(IntegrationTest):
 
     viminput = """
-    * [X] This is a test task  #{uuid}
+    * [X] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -144,11 +145,11 @@ class TestBufferTaskUncompletion(IntegrationTest):
 class TestBufferTaskDeletion(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [D] This is a test task  #{uuid}
+    * [D] This is a test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -176,11 +177,11 @@ class TestBufferTaskDeletion(IntegrationTest):
 class TestBufferTaskUndeletion(IntegrationTest):
 
     viminput = """
-    * [D] This is a test task  #{uuid}
+    * [D] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -208,11 +209,11 @@ class TestBufferTaskUndeletion(IntegrationTest):
 class TestBufferTaskActivation(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [S] This is a test task  #{uuid}
+    * [S] This is a test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -241,11 +242,11 @@ class TestBufferTaskActivation(IntegrationTest):
 class TestBufferTaskDeactivation(IntegrationTest):
 
     viminput = """
-    * [S] This is a test task  #{uuid}
+    * [S] This is a test task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -278,7 +279,7 @@ class TestSimpleTaskWithDueDatetimeCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is a test task (2015-03-03 12:00)  #{uuid}
+    * [ ] This is a test task (2015-03-03 12:00)  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -302,7 +303,7 @@ class TestSimpleTaskWithFlawedDueDatetimeCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is a test task  #{uuid}
+    * [ ] This is a test task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -324,7 +325,7 @@ class TestSimpleTaskWithDueDateCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is a test task (2015-03-03)  #{uuid}
+    * [ ] This is a test task (2015-03-03)  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -344,11 +345,11 @@ class TestSimpleTaskWithDueDateCreation(IntegrationTest):
 class TestSimpleTaskWithDueDatetimeModification(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task (2015-03-03 12:00)  #{uuid}
+    * [ ] This is a test task (2015-03-03 12:00)  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is a test task (2015-03-04 13:00)  #{uuid}
+    * [ ] This is a test task (2015-03-04 13:00)  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -383,7 +384,7 @@ class TestSimpleTaskWithPriorityCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is a test task !!  #{uuid}
+    * [ ] This is a test task !!  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -401,11 +402,11 @@ class TestSimpleTaskWithPriorityCreation(IntegrationTest):
 class TestSimpleTaskWithPriorityModification(IntegrationTest):
 
     viminput = """
-    * [ ] This is a test task !!!  #{uuid}
+    * [ ] This is a test task !!!  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is a test task !  #{uuid}
+    * [ ] This is a test task !  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -438,8 +439,8 @@ class TestChildTaskCreation(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is parent task  #{uuid}
-      * [ ] This is child task  #{uuid}
+    * [ ] This is parent task  """+uuid_char+"""{uuid}
+      * [ ] This is child task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -465,9 +466,9 @@ class TestChildTaskCreationLimit(IntegrationTest):
     """
 
     vimoutput = """
-    * [ ] This is not a parent task  #{uuid}
+    * [ ] This is not a parent task  """+uuid_char+"""{uuid}
     * This is the parent entry
-      * [ ] This is not a child task  #{uuid}
+      * [ ] This is not a child task  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -482,13 +483,13 @@ class TestChildTaskCreationLimit(IntegrationTest):
 class TestChildTaskModification(IntegrationTest):
 
     viminput = """
-    * [ ] This is parent task  #{uuid}
-    * [ ] This is child task  #{uuid}
+    * [ ] This is parent task  """+uuid_char+"""{uuid}
+    * [ ] This is child task  """+uuid_char+"""{uuid}
     """
 
     vimoutput = """
-    * [ ] This is parent task  #{uuid}
-      * [ ] This is child task  #{uuid}
+    * [ ] This is parent task  """+uuid_char+"""{uuid}
+      * [ ] This is child task  """+uuid_char+"""{uuid}
     """
 
     tasks = [
@@ -523,7 +524,7 @@ class TestChildTaskModification(IntegrationTest):
 class TestCreationDifferentTaskSource(MultipleSourceTest):
 
     viminput = """
-    * [ ] This is first data source task  #H:
+    * [ ] This is first data source task  """+uuid_char+"""H:
     """
 
     def execute(self):
@@ -541,7 +542,7 @@ class TestSimpleUnicodeTaskCreation(IntegrationTest):
     """
 
     vimoutput = u"""
-    * [ ] This is a test täsk  #{uuid}
+    * [ ] This is a test täsk  """+uuid_char+"""{uuid}
     """
 
     def execute(self):
@@ -566,8 +567,8 @@ class TestLineNumberPreservation(IntegrationTest):
 
     vimoutput = """
     My tasks for today:
-    * [ ] Wake up  #{uuid}
-    * [ ] Go to sleep in time  #{uuid}
+    * [ ] Wake up  """+uuid_char+"""{uuid}
+    * [ ] Go to sleep in time  """+uuid_char+"""{uuid}
     """
 
     def execute(self):


### PR DESCRIPTION
Allowing the user to modify the `#` prepended to the `{uuid}` at the end of todo items, therefore providing the potential to deconflict with other tools which may reserve the `#` symbol for something such as tags. All the user has to do is set `g:taskwiki_uuid_char` in their configs