### PR TITLE
Concealing Vimwiki Links in Markdown Dialect

### DIFF
--- a/after/syntax/vimwiki.vim
+++ b/after/syntax/vimwiki.vim
@@ -26,6 +26,8 @@ syntax cluster TaskWikiTaskContains
                 \ VimwikiNoExistsLinkT,
                 \ VimwikiWikiLink,
                 \ VimwikiWikiLinkT,
+                \ VimwikiWeblink1,
+                \ VimwikiWikilink1,
                 \ @Spell
 
 " Conceal the UUID


### PR DESCRIPTION
This pull request addresses an issue observed in the 'taskwiki' when using the markdown dialect. Previously, 'taskwiki' did not conceal vimwiki links. With the changes introduced in this pull request, vimwiki links will now be properly concealed, enhancing the user experience.

Before:
<img width="660" alt="taskwiki_before" src="https://github.com/tools-life/taskwiki/assets/13446672/7b8d08db-3d84-4276-9a10-74c730ac4182">

After:
<img width="660" alt="taskwiki_after" src="https://github.com/tools-life/taskwiki/assets/13446672/a42236ee-2070-4338-9c48-475778ce7008">

